### PR TITLE
Feature/deserializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ With the help of Langium, four different products are provided:
 * [The Model Modeling Language](#the-model-modeling-language)
   * [Specification of Metamodels](#on-the-specification-of-metamodels)
   * [Specification of Instances](#on-the-specification-of-instances)
+* [Translating from Ecore to MML](#translating-from-ecore-to-mml)
 * [File structure](#file-structure-where-can-i-find)
 
 ---
@@ -229,6 +230,12 @@ instance <Name> {
     }
 }
 ```
+
+## Translating from Ecore to MML
+The VSCode plugin supports the automatic translation of Ecore files into MML. To do this, right-click on an `.ecore` file 
+and select `Translate Ecore Model to MML`. If successful, the translated `.mml` file will be saved in the `generated` folder.
+
+**Note:** Currently there is no support for metamodels that import additional metamodels.
 
 ## File structure: Where can I find....
 

--- a/README.md
+++ b/README.md
@@ -153,19 +153,21 @@ reference <Type>[1..*] <Name>;
 ```
 
 Attributes and references can additionally be provided with a number of modifiers. These are appended as a simple
-enumeration in curly brackets.
+enumeration in curly brackets (separated by spaces). Note that the meaning of a modifier can be negated by 
+prefixing it with a `!` operator. Modifiers that reflect the default value (see table) do not have to be set explicitly. 
+Therefore, a negation should usually only be necessary for the modifiers `unique`, `ordered` and `resolve`.
 
-| Keyword    | Description | Applicability        |
-|------------|-------------|----------------------|
-| readonly   |             | Attribute, Reference |
-| volatile   |             | Attribute, Reference |
-| transient  |             | Attribute, Reference |
-| unsettable |             | Attribute, Reference |
-| derived    |             | Attribute, Reference |
-| unique     |             | Attribute, Reference |
-| ordered    |             | Attribute, Reference |
-| id         |             | Attribute            |
-| resolve    |             | Reference            |
+| Keyword    | Description | Applicability        | Default |
+|------------|-------------|----------------------|---------|
+| readonly   |             | Attribute, Reference | false   |
+| volatile   |             | Attribute, Reference | false   |
+| transient  |             | Attribute, Reference | false   |
+| unsettable |             | Attribute, Reference | false   |
+| derived    |             | Attribute, Reference | false   |
+| unique     |             | Attribute, Reference | true    |
+| ordered    |             | Attribute, Reference | true    |
+| id         |             | Attribute            | true    |
+| resolve    |             | Reference            | false   |
 
 ### On the specification of instances
 

--- a/package.json
+++ b/package.json
@@ -89,6 +89,11 @@
         "command": "model-modeling-language.serializeToEMF",
         "title": "Generate Ecore/XMI in workspace",
         "category": "Model Modeling Language"
+      },
+      {
+        "command": "model-modeling-language.deserializeEcoreToMML",
+        "title": "Translate Ecore Model to MML",
+        "category": "Model Modeling Language"
       }
     ],
     "menus": {
@@ -99,6 +104,10 @@
         },
         {
           "command": "model-modeling-language.serializeToEMF",
+          "when": "false"
+        },
+        {
+          "command": "model-modeling-language.deserializeEcoreToMML",
           "when": "false"
         }
       ],
@@ -112,6 +121,11 @@
           "when": "resourceExtname == .mml",
           "command": "model-modeling-language.serializeToEMF",
           "group": "navigation"
+        },
+        {
+          "when": "resourceExtname == .ecore",
+          "command": "model-modeling-language.deserializeEcoreToMML",
+          "group": "navigation"
         }
       ],
       "editor/context": [
@@ -123,6 +137,11 @@
         {
           "when": "resourceLangId == model-modeling-language",
           "command": "model-modeling-language.serializeToEMF",
+          "group": "navigation"
+        },
+        {
+          "when": "resourceExtname == .ecore && resourceScheme == file",
+          "command": "model-modeling-language.deserializeEcoreToMML",
           "group": "navigation"
         }
       ]

--- a/src/extension/commands/command-utils.ts
+++ b/src/extension/commands/command-utils.ts
@@ -68,17 +68,25 @@ export function getSerializedWorkspace(client: LanguageClient, ...args: any[]): 
 }
 
 export function writeToFile(enhancedSerializedWorkspace: EnhancedSerializedWorkspace): void {
+export function writeSerializedWorkspaceToFile(enhancedSerializedWorkspace: EnhancedSerializedWorkspace): void {
+    const content: string = JSON.stringify(enhancedSerializedWorkspace.documents);
+    if (writeToFile(enhancedSerializedWorkspace.wsBasePath, `${enhancedSerializedWorkspace.wsName}.json`, content)) {
+        showUIMessage(MessageType.INFO, `Stored serialized workspace in ${enhancedSerializedWorkspace.wsName}.json`);
+    }
+}
+function writeToFile(targetParentDir: string, targetFileName: string, content: string): boolean {
     let fd;
     try {
-        fd = fs.openSync(path.join(enhancedSerializedWorkspace.wsBasePath, `${enhancedSerializedWorkspace.wsName}.json`), "w");
-        fs.writeFileSync(fd, JSON.stringify(enhancedSerializedWorkspace.documents), {encoding: "utf-8"});
+        fs.mkdirSync(targetParentDir, {recursive: true});
+        fd = fs.openSync(path.join(targetParentDir, targetFileName), "w");
+        fs.writeFileSync(fd, content, {encoding: "utf-8"});
     } catch (err) {
-        showUIMessage(MessageType.ERROR, err instanceof Error ? err.message : "Unknown Exception")
+        showUIMessage(MessageType.ERROR, err instanceof Error ? err.message : "Unknown Exception (FILE_WRITE)")
+        return false;
     } finally {
         if (fd !== undefined) {
             fs.closeSync(fd);
-            showUIMessage(MessageType.INFO, `Stored serialized workspace in ${enhancedSerializedWorkspace.wsName}.json`)
-            return;
         }
     }
+    return true;
 }

--- a/src/extension/commands/command-utils.ts
+++ b/src/extension/commands/command-utils.ts
@@ -67,13 +67,28 @@ export function getSerializedWorkspace(client: LanguageClient, ...args: any[]): 
     });
 }
 
-export function writeToFile(enhancedSerializedWorkspace: EnhancedSerializedWorkspace): void {
 export function writeSerializedWorkspaceToFile(enhancedSerializedWorkspace: EnhancedSerializedWorkspace): void {
     const content: string = JSON.stringify(enhancedSerializedWorkspace.documents);
     if (writeToFile(enhancedSerializedWorkspace.wsBasePath, `${enhancedSerializedWorkspace.wsName}.json`, content)) {
         showUIMessage(MessageType.INFO, `Stored serialized workspace in ${enhancedSerializedWorkspace.wsName}.json`);
     }
 }
+
+export function writeGeneratedMmlFile(sourceEcoreFile: vscode.Uri, fileName: string, content: string): void {
+    const workspace = vscode.workspace.getWorkspaceFolder(sourceEcoreFile);
+
+    if (workspace == undefined) {
+        showUIMessage(MessageType.ERROR, "Could not determine workspace!");
+        return;
+    }
+
+    const workspacePath = workspace.uri.fsPath;
+    const targetPath: fs.PathLike = path.join(workspacePath, "generated",);
+    if (writeToFile(targetPath, `${fileName}.mml`, content)) {
+        showUIMessage(MessageType.INFO, `Translated Ecore file to MML (${targetPath})`);
+    }
+}
+
 function writeToFile(targetParentDir: string, targetFileName: string, content: string): boolean {
     let fd;
     try {

--- a/src/extension/commands/command-utils.ts
+++ b/src/extension/commands/command-utils.ts
@@ -1,0 +1,84 @@
+import * as vscode from "vscode";
+import {Uri} from "vscode";
+import {EnhancedSerializedWorkspace, MmlGeneratorRequest, SerializedWorkspace} from "../../shared/MmlConnectorTypes.js";
+import {showUIMessage} from "../../shared/NotificationUtil.js";
+import {MessageType} from "../../shared/MmlNotificationTypes.js";
+import fs from "fs";
+import path from "node:path";
+import {LanguageClient} from "vscode-languageclient/node.js";
+
+export abstract class ExtensionCommand {
+    protected readonly command: string;
+    protected readonly client: LanguageClient;
+    protected readonly logger: vscode.OutputChannel;
+
+    protected constructor(command: string, client: LanguageClient, logger: vscode.OutputChannel) {
+        this.command = command;
+        this.client = client;
+        this.logger = logger;
+    }
+
+    abstract execute(...args: any[]): any;
+
+    register(context: vscode.ExtensionContext) {
+        context.subscriptions.push(vscode.commands.registerCommand(this.command, (...args) => this.execute(...args)));
+    }
+}
+
+
+export function getSerializedWorkspace(client: LanguageClient, ...args: any[]): Promise<EnhancedSerializedWorkspace> {
+    return new Promise<EnhancedSerializedWorkspace>(resolve => {
+        if (args.length == 0) {
+            showUIMessage(MessageType.ERROR, "Could not determine workspace!");
+            resolve({success: false, data: "Could not determine workspace!", documents: [], wsName: "", wsBasePath: ""})
+            return;
+        }
+
+        const {fsPath}: { fsPath: string } = args[0]
+        const fsPathUri: Uri = Uri.file(fsPath);
+
+        const workspace = vscode.workspace.getWorkspaceFolder(fsPathUri);
+
+        if (workspace == undefined) {
+            showUIMessage(MessageType.ERROR, "Could not determine workspace!");
+            resolve({success: false, data: "Could not determine workspace!", documents: [], wsName: "", wsBasePath: ""})
+            return;
+        }
+
+        const workspaceName: string = workspace!.name;
+        const workspacePath = workspace.uri.fsPath;
+
+        const req: MmlGeneratorRequest = {
+            wsBasePath: workspacePath,
+            wsName: workspaceName
+        }
+
+        client.sendRequest("model-modeling-language-get-serialized-workspace", req, undefined)
+            .then((uResponse) => {
+                const res: SerializedWorkspace = uResponse as SerializedWorkspace;
+                resolve({
+                    success: res.success,
+                    data: res.data,
+                    documents: res.documents,
+                    wsName: workspaceName,
+                    wsBasePath: workspacePath
+                });
+            })
+    });
+}
+
+export function writeToFile(enhancedSerializedWorkspace: EnhancedSerializedWorkspace): void {
+    let fd;
+    try {
+        fd = fs.openSync(path.join(enhancedSerializedWorkspace.wsBasePath, `${enhancedSerializedWorkspace.wsName}.json`), "w");
+        fs.writeFileSync(fd, JSON.stringify(enhancedSerializedWorkspace.documents), {encoding: "utf-8"});
+    } catch (err) {
+        showUIMessage(MessageType.ERROR, err instanceof Error ? err.message : "Unknown Exception")
+    } finally {
+        if (fd !== undefined) {
+            fs.closeSync(fd);
+            showUIMessage(MessageType.INFO, `Stored serialized workspace in ${enhancedSerializedWorkspace.wsName}.json`)
+            return;
+        }
+    }
+}

--- a/src/extension/commands/deserialize-ecore-to-mml-command.ts
+++ b/src/extension/commands/deserialize-ecore-to-mml-command.ts
@@ -4,7 +4,7 @@ import * as vscode from "vscode";
 import {showUIMessage} from "../../shared/NotificationUtil.js";
 import {MessageType} from "../../shared/MmlNotificationTypes.js";
 import {spawn} from "node:child_process";
-import {deserializeSerializedCLIDoc} from "../../language/deserializer/mml-deserializer.js";
+import {DeserializedCLIDoc, deserializeSerializedCLIDoc} from "../../language/deserializer/mml-deserializer.js";
 
 export class DeserializeEcoreToMmlCommand extends ExtensionCommand {
     constructor(client: LanguageClient, logger: vscode.OutputChannel) {
@@ -67,13 +67,12 @@ export class DeserializeEcoreToMmlCommand extends ExtensionCommand {
                 const trimmed: string = serializedEcore.trim();
                 if (trimmed.startsWith("[{") && trimmed.endsWith("}]")) {
                     this.logger.appendLine(`[COMPLETED] Start deserializing...`);
-                    const deserialized: {
-                        modelName: string,
-                        modelCode: string
-                    } = deserializeSerializedCLIDoc(trimmed);
-                    this.logger.appendLine(`[COMPLETED] ${deserialized.modelName}`);
-                    this.logger.appendLine(`[COMPLETED] ${deserialized.modelCode}`);
-                    writeGeneratedMmlFile(selection, deserialized.modelName, deserialized.modelCode);
+                    const deserializedCLIDocs: DeserializedCLIDoc[] = deserializeSerializedCLIDoc(trimmed);
+                    this.logger.appendLine(`[COMPLETED] Deserialized ${deserializedCLIDocs.length} documents!`);
+                    deserializedCLIDocs.forEach(dDoc => {
+                        this.logger.appendLine(`[COMPLETED] Writing model file: ${dDoc.modelName}`);
+                        writeGeneratedMmlFile(selection, dDoc.modelName, dDoc.modelCode);
+                    });
                 } else {
                     this.logger.appendLine("=== RECEIVED ===");
                     this.logger.appendLine(trimmed);

--- a/src/extension/commands/deserialize-ecore-to-mml-command.ts
+++ b/src/extension/commands/deserialize-ecore-to-mml-command.ts
@@ -25,7 +25,6 @@ export class DeserializeEcoreToMmlCommand extends ExtensionCommand {
             showUIMessage(MessageType.ERROR, `Invalid selection scheme: ${selection.scheme}`);
             return;
         }
-        showUIMessage(MessageType.INFO, `Got command! Selection: ${selection.fsPath}`);
 
         const workspaceConfiguration = vscode.workspace.getConfiguration('model-modeling-language');
         const connectorPath: string | undefined = workspaceConfiguration.get('cli.path');

--- a/src/extension/commands/deserialize-ecore-to-mml-command.ts
+++ b/src/extension/commands/deserialize-ecore-to-mml-command.ts
@@ -1,0 +1,90 @@
+import {ExtensionCommand, writeGeneratedMmlFile} from "./command-utils.js";
+import {LanguageClient} from "vscode-languageclient/node.js";
+import * as vscode from "vscode";
+import {showUIMessage} from "../../shared/NotificationUtil.js";
+import {MessageType} from "../../shared/MmlNotificationTypes.js";
+import {spawn} from "node:child_process";
+import {deserializeSerializedCLIDoc} from "../../language/deserializer/mml-deserializer.js";
+
+export class DeserializeEcoreToMmlCommand extends ExtensionCommand {
+    constructor(client: LanguageClient, logger: vscode.OutputChannel) {
+        super("model-modeling-language.deserializeEcoreToMML", client, logger);
+    }
+
+    execute(...args: any[]): any {
+        if (args.length == 0 || args.length > 2 || (args.length == 2 && !Array.isArray(args.at(1)))) {
+            showUIMessage(MessageType.ERROR, `Unexpected file selection Please try again or report a bug!`);
+            showUIMessage(MessageType.INFO, JSON.stringify(args));
+            return;
+        } else if (args.length == 2 && args.at(1).length != 1) {
+            showUIMessage(MessageType.ERROR, `You must select a single Ecore file! (You selected ${args.at(1).length})`);
+            return;
+        }
+        const selection: vscode.Uri = args.at(0);
+        if (selection.scheme != "file") {
+            showUIMessage(MessageType.ERROR, `Invalid selection scheme: ${selection.scheme}`);
+            return;
+        }
+        showUIMessage(MessageType.INFO, `Got command! Selection: ${selection.fsPath}`);
+
+        const workspaceConfiguration = vscode.workspace.getConfiguration('model-modeling-language');
+        const connectorPath: string | undefined = workspaceConfiguration.get('cli.path');
+
+        const connectorCommand = `java -jar ${connectorPath} serialize ${selection.fsPath}`;
+
+        let serializedEcore: string = "";
+        let recordData: boolean = false;
+
+        this.logger.appendLine("[INFO] " + "======== Model Modeling Language CLI ========");
+        this.logger.appendLine("[INFO] " + connectorCommand);
+        this.logger.appendLine("[INFO] ");
+
+        const proc = spawn(connectorCommand, {shell: true});
+
+        proc.stdin.setDefaultEncoding('utf8');
+        proc.stdout.setEncoding('utf8');
+
+        proc.stdout.on('data', (data) => {
+            this.logger.appendLine("[INFO] " + data);
+
+            if (typeof data === 'string') {
+                if (recordData) {
+                    serializedEcore += data;
+                } else if (data.trim() == "=$MML-CONTENT-START$=") {
+                    recordData = true;
+                }
+            }
+        });
+
+        proc.stderr.on('data', (data) => {
+            this.logger.appendLine("[ERROR] " + data);
+            showUIMessage(MessageType.ERROR, data);
+        });
+
+        proc.on('close', (code) => {
+            if (code == 0) {
+                this.logger.appendLine(`[COMPLETED] Received data!`);
+                const trimmed: string = serializedEcore.trim();
+                if (trimmed.startsWith("[{") && trimmed.endsWith("}]")) {
+                    this.logger.appendLine(`[COMPLETED] Start deserializing...`);
+                    const deserialized: {
+                        modelName: string,
+                        modelCode: string
+                    } = deserializeSerializedCLIDoc(trimmed);
+                    this.logger.appendLine(`[COMPLETED] ${deserialized.modelName}`);
+                    this.logger.appendLine(`[COMPLETED] ${deserialized.modelCode}`);
+                    writeGeneratedMmlFile(selection, deserialized.modelName, deserialized.modelCode);
+                } else {
+                    this.logger.appendLine("=== RECEIVED ===");
+                    this.logger.appendLine(trimmed);
+                    showUIMessage(MessageType.ERROR, "Failed to parse CLI output!")
+                }
+            } else if (code == 1) {
+                showUIMessage(MessageType.ERROR, `Translation failed!`);
+            } else if (code == 2) {
+                showUIMessage(MessageType.ERROR, `Input failed!`);
+            }
+        });
+    }
+
+}

--- a/src/extension/commands/serialize-to-emf-command.ts
+++ b/src/extension/commands/serialize-to-emf-command.ts
@@ -27,6 +27,12 @@ export class SerializeToEmfCommand extends ExtensionCommand {
                 return;
             }
 
+            if (value.documents.filter(x => x.diagnostics.filter(y => y.severity == 1).length > 0).length > 0) {
+                showUIMessage(MessageType.ERROR, "Generation cannot be carried out as there are still some problems of the highest severity!");
+                vscode.commands.executeCommand("workbench.action.problems.focus");
+                return;
+            }
+
             const connectorCommand = `java -jar ${connectorPath} generate ${value.wsName} ${value.wsBasePath}`;
             const connectorMessage = JSON.stringify(value.documents);
 

--- a/src/extension/commands/serialize-to-emf-command.ts
+++ b/src/extension/commands/serialize-to-emf-command.ts
@@ -1,0 +1,65 @@
+import {ExtensionCommand, getSerializedWorkspace} from "./command-utils.js";
+import {LanguageClient} from "vscode-languageclient/node.js";
+import * as vscode from "vscode";
+import fs from "fs";
+import {showInteractiveUIMessage, showUIMessage} from "../../shared/NotificationUtil.js";
+import {MessageType} from "../../shared/MmlNotificationTypes.js";
+import {spawn} from "node:child_process";
+import os from "os";
+
+export class SerializeToEmfCommand extends ExtensionCommand {
+
+    constructor(client: LanguageClient, logger: vscode.OutputChannel) {
+        super("model-modeling-language.serializeToEMF", client, logger);
+    }
+
+    execute(...args: any[]): any {
+        getSerializedWorkspace(this.client, ...args).then(value => {
+            const workspaceConfiguration = vscode.workspace.getConfiguration('model-modeling-language');
+            const connectorPath: string | undefined = workspaceConfiguration.get('cli.path');
+
+            if (connectorPath == undefined || connectorPath == "" || !fs.existsSync(connectorPath)) {
+                showInteractiveUIMessage(MessageType.ERROR, "Could not find the model-modeling-language-cli! Check if the correct path is set!", ["Check settings"]).then((sel: string | undefined) => {
+                    if (sel != undefined && sel == "Check settings") {
+                        vscode.commands.executeCommand('workbench.action.openSettings', 'model-modeling-language.cli.path');
+                    }
+                });
+                return;
+            }
+
+            const connectorCommand = `java -jar ${connectorPath} generate ${value.wsName} ${value.wsBasePath}`;
+            const connectorMessage = JSON.stringify(value.documents);
+
+            this.logger.appendLine("[INFO] " + "======== Model Modeling Language CLI ========");
+            this.logger.appendLine("[INFO] " + connectorCommand);
+            this.logger.appendLine("[INFO] ");
+
+            const proc = spawn(connectorCommand, {shell: true});
+
+            proc.stdin.setDefaultEncoding('utf8');
+            proc.stdout.setEncoding('utf8');
+            proc.stdin.write(connectorMessage + os.EOL);
+
+            proc.stdout.on('data', (data) => {
+                this.logger.appendLine("[INFO] " + data);
+            });
+
+            proc.stderr.on('data', (data) => {
+                this.logger.appendLine("[ERROR] " + data);
+                showUIMessage(MessageType.ERROR, data);
+            });
+
+            proc.on('close', (code) => {
+                if (code == 0) {
+                    showUIMessage(MessageType.INFO, `Stored generated Ecore/XMI files in the model directory`);
+                } else if (code == 1) {
+                    showUIMessage(MessageType.ERROR, `Deserialization failed!`);
+                } else if (code == 2) {
+                    showUIMessage(MessageType.ERROR, `Input failed!`);
+                }
+            });
+        })
+    }
+
+
+}

--- a/src/extension/commands/serialize-to-file-command.ts
+++ b/src/extension/commands/serialize-to-file-command.ts
@@ -10,9 +10,11 @@ export class SerializeToFileCommand extends ExtensionCommand {
     }
 
     execute(...args: any[]): any {
-        //showUIMessage(MessageType.INFO, "Got command!");
         getSerializedWorkspace(this.client, ...args).then(value => {
             if (value.success) {
+                if (value.documents.filter(x => x.diagnostics.filter(y => y.severity == 1).length > 0).length > 0) {
+                    showUIMessage(MessageType.WARNING, "Generation was carried out, although there are still some problems of the highest severity!");
+                }
                 writeSerializedWorkspaceToFile(value);
             } else {
                 showUIMessage(MessageType.ERROR, value.data);

--- a/src/extension/commands/serialize-to-file-command.ts
+++ b/src/extension/commands/serialize-to-file-command.ts
@@ -1,0 +1,23 @@
+import {ExtensionCommand, getSerializedWorkspace, writeToFile} from "./command-utils.js";
+import {LanguageClient} from "vscode-languageclient/node.js";
+import * as vscode from "vscode";
+import {showUIMessage} from "../../shared/NotificationUtil.js";
+import {MessageType} from "../../shared/MmlNotificationTypes.js";
+
+export class SerializeToFileCommand extends ExtensionCommand {
+    constructor(client: LanguageClient, logger: vscode.OutputChannel) {
+        super("model-modeling-language.serializeToFile", client, logger);
+    }
+
+    execute(...args: any[]): any {
+        //showUIMessage(MessageType.INFO, "Got command!");
+        getSerializedWorkspace(this.client, ...args).then(value => {
+            if (value.success) {
+                writeToFile(value);
+            } else {
+                showUIMessage(MessageType.ERROR, value.data);
+            }
+        })
+    }
+
+}

--- a/src/extension/commands/serialize-to-file-command.ts
+++ b/src/extension/commands/serialize-to-file-command.ts
@@ -1,4 +1,4 @@
-import {ExtensionCommand, getSerializedWorkspace, writeToFile} from "./command-utils.js";
+import {ExtensionCommand, getSerializedWorkspace, writeSerializedWorkspaceToFile} from "./command-utils.js";
 import {LanguageClient} from "vscode-languageclient/node.js";
 import * as vscode from "vscode";
 import {showUIMessage} from "../../shared/NotificationUtil.js";
@@ -13,7 +13,7 @@ export class SerializeToFileCommand extends ExtensionCommand {
         //showUIMessage(MessageType.INFO, "Got command!");
         getSerializedWorkspace(this.client, ...args).then(value => {
             if (value.success) {
-                writeToFile(value);
+                writeSerializedWorkspaceToFile(value);
             } else {
                 showUIMessage(MessageType.ERROR, value.data);
             }

--- a/src/extension/main.ts
+++ b/src/extension/main.ts
@@ -1,14 +1,9 @@
 import type {LanguageClientOptions, ServerOptions} from 'vscode-languageclient/node.js';
 import {LanguageClient, TransportKind} from 'vscode-languageclient/node.js';
-import {EnhancedSerializedWorkspace, MmlGeneratorRequest, SerializedWorkspace} from "../shared/MmlConnectorTypes.js";
 import * as vscode from 'vscode';
-import {Uri} from 'vscode';
 import * as path from 'node:path';
-import {showInteractiveUIMessage, showUIMessage} from "../shared/NotificationUtil.js";
-import {MessageType} from "../shared/MmlNotificationTypes.js";
-import fs from "fs";
-import {spawn} from "node:child_process";
-import * as os from "os";
+import {SerializeToFileCommand} from "./commands/serialize-to-file-command.js";
+import {SerializeToEmfCommand} from "./commands/serialize-to-emf-command.js";
 
 let client: LanguageClient;
 let logger: vscode.OutputChannel;
@@ -68,120 +63,7 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
     return client;
 }
 
-function getSerializedWorkspace(...args: any[]): Promise<EnhancedSerializedWorkspace> {
-    return new Promise<EnhancedSerializedWorkspace>(resolve => {
-        if (args.length == 0) {
-            showUIMessage(MessageType.ERROR, "Could not determine workspace!");
-            resolve({success: false, data: "Could not determine workspace!", documents: [], wsName: "", wsBasePath: ""})
-            return;
-        }
-
-        const {fsPath}: { fsPath: string } = args[0]
-        const fsPathUri: Uri = Uri.file(fsPath);
-
-        const workspace = vscode.workspace.getWorkspaceFolder(fsPathUri);
-
-        if (workspace == undefined) {
-            showUIMessage(MessageType.ERROR, "Could not determine workspace!");
-            resolve({success: false, data: "Could not determine workspace!", documents: [], wsName: "", wsBasePath: ""})
-            return;
-        }
-
-        const workspaceName: string = workspace!.name;
-        const workspacePath = workspace.uri.fsPath;
-
-        const req: MmlGeneratorRequest = {
-            wsBasePath: workspacePath,
-            wsName: workspaceName
-        }
-
-        client.sendRequest("model-modeling-language-get-serialized-workspace", req, undefined)
-            .then((uResponse) => {
-                const res: SerializedWorkspace = uResponse as SerializedWorkspace;
-                resolve({
-                    success: res.success,
-                    data: res.data,
-                    documents: res.documents,
-                    wsName: workspaceName,
-                    wsBasePath: workspacePath
-                });
-            })
-    });
-}
-
-function writeToFile(enhancedSerializedWorkspace: EnhancedSerializedWorkspace): void {
-    let fd;
-    try {
-        fd = fs.openSync(path.join(enhancedSerializedWorkspace.wsBasePath, `${enhancedSerializedWorkspace.wsName}.json`), "w");
-        fs.writeFileSync(fd, JSON.stringify(enhancedSerializedWorkspace.documents), {encoding: "utf-8"});
-    } catch (err) {
-        showUIMessage(MessageType.ERROR, err instanceof Error ? err.message : "Unknown Exception")
-    } finally {
-        if (fd !== undefined) {
-            fs.closeSync(fd);
-            showUIMessage(MessageType.INFO, `Stored serialized workspace in ${enhancedSerializedWorkspace.wsName}.json`)
-            return;
-        }
-    }
-}
-
 function registerCommands(context: vscode.ExtensionContext) {
-    context.subscriptions.push(vscode.commands.registerCommand("model-modeling-language.serializeToFile", function (...args) {
-        //showUIMessage(MessageType.INFO, "Got command!");
-        getSerializedWorkspace(...args).then(value => {
-            if (value.success) {
-                writeToFile(value);
-            } else {
-                showUIMessage(MessageType.ERROR, value.data);
-            }
-        })
-    }));
-
-    context.subscriptions.push(vscode.commands.registerCommand("model-modeling-language.serializeToEMF", function (...args) {
-        getSerializedWorkspace(...args).then(value => {
-            const workspaceConfiguration = vscode.workspace.getConfiguration('model-modeling-language');
-            const connectorPath: string | undefined = workspaceConfiguration.get('cli.path');
-
-            if (connectorPath == undefined || connectorPath == "" || !fs.existsSync(connectorPath)) {
-                showInteractiveUIMessage(MessageType.ERROR, "Could not find the model-modeling-language-cli! Check if the correct path is set!", ["Check settings"]).then((sel: string | undefined) => {
-                    if (sel != undefined && sel == "Check settings") {
-                        vscode.commands.executeCommand('workbench.action.openSettings', 'model-modeling-language.cli.path');
-                    }
-                });
-                return;
-            }
-
-            const connectorCommand = `java -jar ${connectorPath} generate ${value.wsName} ${value.wsBasePath}`;
-            const connectorMessage = JSON.stringify(value.documents);
-
-            logger.appendLine("[INFO] " + "======== Model Modeling Language CLI ========");
-            logger.appendLine("[INFO] " + connectorCommand);
-            logger.appendLine("[INFO] ");
-
-            const proc = spawn(connectorCommand, {shell: true});
-
-            proc.stdin.setDefaultEncoding('utf8');
-            proc.stdout.setEncoding('utf8');
-            proc.stdin.write(connectorMessage + os.EOL);
-
-            proc.stdout.on('data', (data) => {
-                logger.appendLine("[INFO] " + data);
-            });
-
-            proc.stderr.on('data', (data) => {
-                logger.appendLine("[ERROR] " + data);
-                showUIMessage(MessageType.ERROR, data);
-            });
-
-            proc.on('close', (code) => {
-                if (code == 0) {
-                    showUIMessage(MessageType.INFO, `Stored generated Ecore/XMI files in the model directory`);
-                } else if (code == 1) {
-                    showUIMessage(MessageType.ERROR, `Deserialization failed!`);
-                } else if (code == 2) {
-                    showUIMessage(MessageType.ERROR, `Input failed!`);
-                }
-            });
-        })
-    }));
+    new SerializeToFileCommand(client, logger).register(context);
+    new SerializeToEmfCommand(client, logger).register(context);
 }

--- a/src/extension/main.ts
+++ b/src/extension/main.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import * as path from 'node:path';
 import {SerializeToFileCommand} from "./commands/serialize-to-file-command.js";
 import {SerializeToEmfCommand} from "./commands/serialize-to-emf-command.js";
+import {DeserializeEcoreToMmlCommand} from "./commands/deserialize-ecore-to-mml-command.js";
 
 let client: LanguageClient;
 let logger: vscode.OutputChannel;
@@ -66,4 +67,5 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
 function registerCommands(context: vscode.ExtensionContext) {
     new SerializeToFileCommand(client, logger).register(context);
     new SerializeToEmfCommand(client, logger).register(context);
+    new DeserializeEcoreToMmlCommand(client, logger).register(context);
 }

--- a/src/language/deserializer/mml-deserializer.ts
+++ b/src/language/deserializer/mml-deserializer.ts
@@ -11,15 +11,22 @@ export function deserializeStringToMMLCode(serialized: string, idStorage: MmlIdS
     return toString(deserializeModel(typegraph, idStorage));
 }
 
-export function deserializeSerializedCLIDoc(cliDoc: string): { modelName: string, modelCode: string } {
+export type DeserializedCLIDoc = {
+    modelName: string;
+    modelCode: string
+}
+
+export function deserializeSerializedCLIDoc(cliDoc: string): DeserializedCLIDoc[] {
     const sDocs: SerializedDocument[] = JSON.parse(cliDoc);
     const idStorage: MmlIdStorage = new MmlIdStorage(sDocs);
     if (sDocs == undefined || sDocs.length != 1) {
         throw new Error("Unexpected number of serialized documents received!");
     }
-    const sDoc: SerializedDocument = sDocs.at(0)!;
-    const uniformUri: string = Uri.parse(sDoc.uri).path;
-    const modelName: string = uniformUri.substring(uniformUri.lastIndexOf("/") + 1).replace(".ecore", "").replace(".mml", "");
-    const modelCode: string = deserializeStringToMMLCode(sDoc.content, idStorage);
-    return {modelName: modelName, modelCode: modelCode};
+
+    return sDocs.map(sDoc => {
+        const uniformUri: string = Uri.parse(sDoc.uri).path;
+        const modelName: string = uniformUri.substring(uniformUri.lastIndexOf("/") + 1).replace(".ecore", "").replace(".mml", "");
+        const modelCode: string = deserializeStringToMMLCode(sDoc.content, idStorage);
+        return {modelName: modelName, modelCode: modelCode} as DeserializedCLIDoc;
+    })
 }

--- a/src/language/deserializer/mml-deserializer.ts
+++ b/src/language/deserializer/mml-deserializer.ts
@@ -1,0 +1,9 @@
+import {SerializedModel} from "../serializer/mml-entity-templates.js";
+import {SerializedInstances} from "../serializer/mml-instance-templates.js";
+import {deserializeModel} from "./mml-entity-deserializer.js";
+import {toString} from "langium";
+
+export function deserializeStringToMMLCode(serialized: string): string {
+    const {typegraph}: { typegraph: SerializedModel, instancegraph: SerializedInstances } = JSON.parse(serialized)
+    return toString(deserializeModel(typegraph));
+}

--- a/src/language/deserializer/mml-deserializer.ts
+++ b/src/language/deserializer/mml-deserializer.ts
@@ -1,9 +1,8 @@
 import {SerializedModel} from "../serializer/mml-entity-templates.js";
 import {SerializedInstances} from "../serializer/mml-instance-templates.js";
 import {deserializeModel} from "./mml-entity-deserializer.js";
-import {toString} from "langium";
+import {toString, URI} from "langium";
 import {SerializedDocument} from "../../shared/MmlConnectorTypes.js";
-import {Uri} from "vscode";
 import {MmlIdStorage} from "./mml-id-storage.js";
 
 export function deserializeStringToMMLCode(serialized: string, idStorage: MmlIdStorage): string {
@@ -24,7 +23,7 @@ export function deserializeSerializedCLIDoc(cliDoc: string): DeserializedCLIDoc[
     }
 
     return sDocs.map(sDoc => {
-        const uniformUri: string = Uri.parse(sDoc.uri).path;
+        const uniformUri: string = URI.parse(sDoc.uri).path;
         const modelName: string = uniformUri.substring(uniformUri.lastIndexOf("/") + 1).replace(".ecore", "").replace(".mml", "");
         const modelCode: string = deserializeStringToMMLCode(sDoc.content, idStorage);
         return {modelName: modelName, modelCode: modelCode} as DeserializedCLIDoc;

--- a/src/language/deserializer/mml-deserializer.ts
+++ b/src/language/deserializer/mml-deserializer.ts
@@ -2,8 +2,24 @@ import {SerializedModel} from "../serializer/mml-entity-templates.js";
 import {SerializedInstances} from "../serializer/mml-instance-templates.js";
 import {deserializeModel} from "./mml-entity-deserializer.js";
 import {toString} from "langium";
+import {SerializedDocument} from "../../shared/MmlConnectorTypes.js";
+import {Uri} from "vscode";
+import {MmlIdStorage} from "./mml-id-storage.js";
 
-export function deserializeStringToMMLCode(serialized: string): string {
+export function deserializeStringToMMLCode(serialized: string, idStorage: MmlIdStorage): string {
     const {typegraph}: { typegraph: SerializedModel, instancegraph: SerializedInstances } = JSON.parse(serialized)
-    return toString(deserializeModel(typegraph));
+    return toString(deserializeModel(typegraph, idStorage));
+}
+
+export function deserializeSerializedCLIDoc(cliDoc: string): { modelName: string, modelCode: string } {
+    const sDocs: SerializedDocument[] = JSON.parse(cliDoc);
+    const idStorage: MmlIdStorage = new MmlIdStorage(sDocs);
+    if (sDocs == undefined || sDocs.length != 1) {
+        throw new Error("Unexpected number of serialized documents received!");
+    }
+    const sDoc: SerializedDocument = sDocs.at(0)!;
+    const uniformUri: string = Uri.parse(sDoc.uri).path;
+    const modelName: string = uniformUri.substring(uniformUri.lastIndexOf("/") + 1).replace(".ecore", "").replace(".mml", "");
+    const modelCode: string = deserializeStringToMMLCode(sDoc.content, idStorage);
+    return {modelName: modelName, modelCode: modelCode};
 }

--- a/src/language/deserializer/mml-entity-deserializer.ts
+++ b/src/language/deserializer/mml-entity-deserializer.ts
@@ -10,6 +10,7 @@ import {
     ReferenceEntity,
     SerializedModel
 } from "../serializer/mml-entity-templates.js";
+import {MmlIdStorage} from "./mml-id-storage.js";
 
 function joinWithExtraNL<T>(content: T[], toString: (e: T) => Generated): Generated {
     return join(content, toString, {appendNewLineIfNotEmpty: true});
@@ -22,37 +23,37 @@ function setSpacedKeywordIf(keyword: string, condition: boolean): Generated {
     return toNode``;
 }
 
-export function deserializeModel(model: SerializedModel): Generated {
-    return toNode`${joinWithExtraNL(model.packages, pkg => deserializePackage(pkg))}`
+export function deserializeModel(model: SerializedModel, idStorage: MmlIdStorage): Generated {
+    return toNode`${joinWithExtraNL(model.packages, pkg => deserializePackage(pkg, idStorage))}`
 }
 
-function deserializePackage(packageEntity: PackageEntity): Generated {
+function deserializePackage(packageEntity: PackageEntity, idStorage: MmlIdStorage): Generated {
     return toNode`
         package ${packageEntity.name} {
             ${joinWithExtraNL(packageEntity.enums, x => deserializeEnum(x))}
-            ${joinWithExtraNL(packageEntity.abstractClasses, x => deserializeAbstractClassEntity(x))}
-            ${joinWithExtraNL(packageEntity.subPackages, x => deserializePackage(x))}
+            ${joinWithExtraNL(packageEntity.abstractClasses, x => deserializeAbstractClassEntity(x, idStorage))}
+            ${joinWithExtraNL(packageEntity.subPackages, x => deserializePackage(x, idStorage))}
         }
         `
 }
 
-function deserializeAbstractClassEntity(ace: AbstractClassEntity): Generated {
+function deserializeAbstractClassEntity(ace: AbstractClassEntity, idStorage: MmlIdStorage): Generated {
     return toNode`
-        ${setSpacedKeywordIf("abstract", ace.isAbstract)}${setSpacedKeywordIf("interface", ace.isInterface)}class ${ace.name} ${setSpacedKeywordIf("extends " + ace.extendsIds.join(","), ace.extendsIds.length > 0)}${setSpacedKeywordIf("implements " + ace.implementsIds.join(","), ace.implementsIds.length > 0)}{
-            ${joinWithExtraNL(ace.attributes, x => deserializeAttribute(x))}
-            ${joinWithExtraNL(ace.references, x => deserializeReference(x))}
+        ${setSpacedKeywordIf("abstract", ace.isAbstract)}${setSpacedKeywordIf("interface", ace.isInterface)}class ${ace.name} ${setSpacedKeywordIf("extends " + ace.extendsIds.map(x => idStorage.resolveId(x)).join(","), ace.extendsIds.length > 0)}${setSpacedKeywordIf("implements " + ace.implementsIds.map(x => idStorage.resolveId(x)).join(","), ace.implementsIds.length > 0)}{
+            ${joinWithExtraNL(ace.attributes, x => deserializeAttribute(x, idStorage))}
+            ${joinWithExtraNL(ace.references, x => deserializeReference(x, idStorage))}
         }
         `
 }
 
-function deserializeAttribute(attribute: AttributeEntity): Generated {
+function deserializeAttribute(attribute: AttributeEntity, idStorage: MmlIdStorage): Generated {
     if (attribute.hasDefaultValue) {
         return toNode`
-        attribute ${attribute.type} ${attribute.name} = ${attribute.defaultValue}${deserializeClassElementModifiers(attribute.modifiers)};
+        attribute ${attribute.isEnumType ? idStorage.resolveId(attribute.type) : attribute.type} ${attribute.name} = ${attribute.isEnumType ? idStorage.resolveId(attribute.defaultValue as string) : attribute.defaultValue}${deserializeClassElementModifiers(attribute.modifiers)};
         `;
     } else {
         return toNode`
-        attribute ${attribute.type} ${attribute.name}${deserializeClassElementModifiers(attribute.modifiers)};
+        attribute ${attribute.isEnumType ? idStorage.resolveId(attribute.type) : attribute.type} ${attribute.name}${deserializeClassElementModifiers(attribute.modifiers)};
         `;
     }
 }
@@ -62,13 +63,13 @@ function deserializeClassElementModifiers(cem: ClassElementModifiers): Generated
     return modifiers.length == 0 ? toNode`` : toNode` {${modifiers.join(" ")}}`;
 }
 
-function deserializeReference(reference: ReferenceEntity): Generated {
+function deserializeReference(reference: ReferenceEntity, idStorage: MmlIdStorage): Generated {
     if (reference.hasOpposite) {
         return toNode`
-        @opposite ${reference.opposite}
-        reference ${reference.type}${deserializeMultiplicity(reference.multiplicity)} ${reference.name}${deserializeClassElementModifiers(reference.modifiers)};`;
+        @opposite ${idStorage.resolveId(reference.opposite)}
+        reference ${idStorage.resolveId(reference.type)}${deserializeMultiplicity(reference.multiplicity)} ${reference.name}${deserializeClassElementModifiers(reference.modifiers)};`;
     } else {
-        return toNode`reference ${reference.type}${deserializeMultiplicity(reference.multiplicity)} ${reference.name}${deserializeClassElementModifiers(reference.modifiers)};`;
+        return toNode`reference ${idStorage.resolveId(reference.type)}${deserializeMultiplicity(reference.multiplicity)} ${reference.name}${deserializeClassElementModifiers(reference.modifiers)};`;
     }
 }
 

--- a/src/language/deserializer/mml-entity-deserializer.ts
+++ b/src/language/deserializer/mml-entity-deserializer.ts
@@ -49,7 +49,7 @@ function deserializeAbstractClassEntity(ace: AbstractClassEntity, idStorage: Mml
 function deserializeAttribute(attribute: AttributeEntity, idStorage: MmlIdStorage): Generated {
     if (attribute.hasDefaultValue) {
         return toNode`
-        attribute ${attribute.isEnumType ? idStorage.resolveId(attribute.type) : attribute.type} ${attribute.name} = ${attribute.isEnumType ? idStorage.resolveId(attribute.defaultValue as string) : attribute.defaultValue}${deserializeClassElementModifiers(attribute.modifiers, true)};
+        attribute ${attribute.isEnumType ? idStorage.resolveId(attribute.type) : attribute.type} ${attribute.name} = ${attribute.isEnumType ? idStorage.resolveId(attribute.defaultValue as string) : attribute.type == "string" ? `"${attribute.defaultValue}"` : attribute.defaultValue}${deserializeClassElementModifiers(attribute.modifiers, true)};
         `;
     } else {
         return toNode`

--- a/src/language/deserializer/mml-entity-deserializer.ts
+++ b/src/language/deserializer/mml-entity-deserializer.ts
@@ -1,0 +1,99 @@
+import {expandToNode as toNode, type Generated, joinToNode as join} from "langium";
+import {
+    AbstractClassEntity,
+    AttributeEntity,
+    ClassElementModifiers,
+    EnumEntity,
+    EnumEntryEntity,
+    MultiplicityEntity,
+    PackageEntity,
+    ReferenceEntity,
+    SerializedModel
+} from "../serializer/mml-entity-templates.js";
+
+function joinWithExtraNL<T>(content: T[], toString: (e: T) => Generated): Generated {
+    return join(content, toString, {appendNewLineIfNotEmpty: true});
+}
+
+function setSpacedKeywordIf(keyword: string, condition: boolean): Generated {
+    if (condition) {
+        return toNode`${keyword} `;
+    }
+    return toNode``;
+}
+
+export function deserializeModel(model: SerializedModel): Generated {
+    return toNode`${joinWithExtraNL(model.packages, pkg => deserializePackage(pkg))}`
+}
+
+function deserializePackage(packageEntity: PackageEntity): Generated {
+    return toNode`
+        package ${packageEntity.name} {
+            ${joinWithExtraNL(packageEntity.enums, x => deserializeEnum(x))}
+            ${joinWithExtraNL(packageEntity.abstractClasses, x => deserializeAbstractClassEntity(x))}
+            ${joinWithExtraNL(packageEntity.subPackages, x => deserializePackage(x))}
+        }
+        `
+}
+
+function deserializeAbstractClassEntity(ace: AbstractClassEntity): Generated {
+    return toNode`
+        ${setSpacedKeywordIf("abstract", ace.isAbstract)}${setSpacedKeywordIf("interface", ace.isInterface)}class ${ace.name} ${setSpacedKeywordIf("extends " + ace.extendsIds.join(","), ace.extendsIds.length > 0)}${setSpacedKeywordIf("implements " + ace.implementsIds.join(","), ace.implementsIds.length > 0)}{
+            ${joinWithExtraNL(ace.attributes, x => deserializeAttribute(x))}
+            ${joinWithExtraNL(ace.references, x => deserializeReference(x))}
+        }
+        `
+}
+
+function deserializeAttribute(attribute: AttributeEntity): Generated {
+    if (attribute.hasDefaultValue) {
+        return toNode`
+        attribute ${attribute.type} ${attribute.name} = ${attribute.defaultValue}${deserializeClassElementModifiers(attribute.modifiers)};
+        `;
+    } else {
+        return toNode`
+        attribute ${attribute.type} ${attribute.name}${deserializeClassElementModifiers(attribute.modifiers)};
+        `;
+    }
+}
+
+function deserializeClassElementModifiers(cem: ClassElementModifiers): Generated {
+    const modifiers: string[] = [cem.readonly ? "readonly" : "", cem.volatile ? "volatile" : "", cem.transient ? "transient" : "", cem.unsettable ? "unsettable" : "", cem.derived ? "derived" : "", cem.unique ? "unique" : "", cem.ordered ? "ordered" : "", cem.resolve ? "resolve" : "", cem.id ? "id" : ""].filter(x => x != "");
+    return modifiers.length == 0 ? toNode`` : toNode` {${modifiers.join(" ")}}`;
+}
+
+function deserializeReference(reference: ReferenceEntity): Generated {
+    if (reference.hasOpposite) {
+        return toNode`
+        @opposite ${reference.opposite}
+        reference ${reference.type}${deserializeMultiplicity(reference.multiplicity)} ${reference.name}${deserializeClassElementModifiers(reference.modifiers)};`;
+    } else {
+        return toNode`reference ${reference.type}${deserializeMultiplicity(reference.multiplicity)} ${reference.name}${deserializeClassElementModifiers(reference.modifiers)};`;
+    }
+}
+
+function deserializeMultiplicity(mult: MultiplicityEntity): Generated {
+    const lower: string = mult.lowerIsN0 ? "*" : mult.lowerIsN ? "+" : mult.lower.toString();
+    const upper: string = mult.upperIsN0 ? "*" : mult.upperIsN ? "+" : mult.upper.toString();
+    if (mult.hasUpperBound) {
+        return toNode`[${lower}..${upper}]`;
+    } else {
+        return toNode`[${lower}]`;
+    }
+}
+
+function deserializeEnum(enumEntity: EnumEntity): Generated {
+    return toNode`
+    enum ${enumEntity.name} {
+        ${join(enumEntity.entries, x => deserializeEnumEntryEntity(x), {separator: ",", appendNewLineIfNotEmpty: true})}
+    }
+    `
+}
+
+function deserializeEnumEntryEntity(entry: EnumEntryEntity): Generated {
+    if (entry.hasDefaultValue) {
+        return toNode`${entry.name} = ${entry.defaultValue}`
+    } else {
+        return toNode`${entry.name}`
+    }
+}

--- a/src/language/deserializer/mml-entity-deserializer.ts
+++ b/src/language/deserializer/mml-entity-deserializer.ts
@@ -71,6 +71,7 @@ function deserializeClassElementModifiers(cem: ClassElementModifiers, isAttribut
         modifiers.push(...modifierDefaultRealizer(cem.id, false, "id"));
     } else {
         modifiers.push(...modifierDefaultRealizer(cem.resolve, true, "resolve"));
+        modifiers.push(...modifierDefaultRealizer(cem.containment, false, "containment"));
     }
     return modifiers.length == 0 ? toNode`` : toNode` {${modifiers.join(" ")}}`;
 }

--- a/src/language/deserializer/mml-entity-deserializer.ts
+++ b/src/language/deserializer/mml-entity-deserializer.ts
@@ -100,6 +100,9 @@ function deserializeMultiplicity(mult: MultiplicityEntity): Generated {
     const lower: string = mult.lowerIsN0 ? "*" : mult.lowerIsN ? "+" : mult.lower.toString();
     const upper: string = mult.upperIsN0 ? "*" : mult.upperIsN ? "+" : mult.upper.toString();
     if (mult.hasUpperBound) {
+        if (!mult.lowerIsN0 && !mult.lowerIsN && !mult.upperIsN0 && !mult.upperIsN && mult.lower == 0 && mult.upper == 1) {
+            return toNode``;
+        }
         return toNode`[${lower}..${upper}]`;
     } else {
         return toNode`[${lower}]`;

--- a/src/language/deserializer/mml-id-storage.ts
+++ b/src/language/deserializer/mml-id-storage.ts
@@ -1,0 +1,49 @@
+import {SerializedDocument} from "../../shared/MmlConnectorTypes.js";
+import {PackageEntity, SerializedModel} from "../serializer/mml-entity-templates.js";
+import {SerializedInstances} from "../serializer/mml-instance-templates.js";
+
+export class MmlIdStorage {
+    private knownIds: Map<string, string> = new Map<string, string>();
+
+
+    constructor(sDocs: SerializedDocument[]) {
+        sDocs.forEach(sDoc => {
+            const {typegraph}: {
+                typegraph: SerializedModel,
+                instancegraph: SerializedInstances
+            } = JSON.parse(sDoc.content);
+            typegraph.packages.forEach(pckg => {
+                this.initializePackage(pckg, "");
+            })
+        })
+    }
+
+    private initializePackage(pckg: PackageEntity, prefix: string) {
+        this.storeElementId(pckg.referenceId, prefix + pckg.name);
+        pckg.subPackages.forEach(sPckg => {
+            this.initializePackage(sPckg, prefix + pckg.name + ".");
+        })
+        pckg.enums.forEach(enm => {
+            this.storeElementId(enm.referenceId, prefix + pckg.name + "." + enm.name);
+            enm.entries.forEach(enmEntry => {
+                this.storeElementId(enmEntry.referenceId, prefix + pckg.name + "." + enm.name + "::" + enmEntry.name);
+            })
+        })
+        pckg.abstractClasses.forEach(ac => {
+            this.storeElementId(ac.referenceId, prefix + pckg.name + "." + ac.name);
+            ac.references.forEach(ref => {
+                this.storeElementId(ref.referenceId, prefix + pckg.name + "." + ac.name + "::" + ref.name);
+            })
+        })
+    }
+
+    public storeElementId(id: string, elementName: string): void {
+        if (!this.knownIds.has(id)) {
+            this.knownIds.set(id, elementName);
+        }
+    }
+
+    public resolveId(id: string): string {
+        return this.knownIds.get(id) ?? "$$UNKNOWN$$";
+    }
+}

--- a/src/language/model-modeling-language-code-action-provider.ts
+++ b/src/language/model-modeling-language-code-action-provider.ts
@@ -51,6 +51,14 @@ export class ModelModelingLanguageCodeActionProvider implements CodeActionProvid
             case IssueCodes.OppositesOppositeAnnotationMissing:
                 accept(this.fixMissingOppositesOppositeAnnotation(diagnostic, document));
                 break;
+            case IssueCodes.UnnecessaryAttributeModifier:
+            case IssueCodes.UnnecessaryReferenceModifier:
+                accept(this.fixUnnecessaryModifiers(diagnostic, document));
+                break;
+            case IssueCodes.InvalidAttributeModifierCombination:
+            case IssueCodes.InvalidReferenceModifierCombination:
+                accept(this.fixInvalidModifierCombination(diagnostic, document));
+                break;
         }
         return undefined;
     }
@@ -190,6 +198,48 @@ export class ModelModelingLanguageCodeActionProvider implements CodeActionProvid
         }
         return undefined;
     }
+
+    private fixUnnecessaryModifiers(diagnostic: Diagnostic, document: LangiumDocument): CodeAction | undefined {
+        const text = document.textDocument.getText(diagnostic.range);
+        if (text) {
+            return {
+                title: `Remove unnecessary modifier ${text}`,
+                kind: CodeActionKind.QuickFix,
+                diagnostics: [diagnostic],
+                edit: {
+                    changes: {
+                        [document.textDocument.uri]: [{
+                            range: diagnostic.range,
+                            newText: ""
+                        }]
+                    }
+                }
+            };
+        }
+        return undefined;
+    }
+
+    private fixInvalidModifierCombination(diagnostic: Diagnostic, document: LangiumDocument): CodeAction | undefined {
+        const text = document.textDocument.getText(diagnostic.range);
+        if (text) {
+            return {
+                title: `Remove invalid modifier ${text}`,
+                kind: CodeActionKind.QuickFix,
+                diagnostics: [diagnostic],
+                edit: {
+                    changes: {
+                        [document.textDocument.uri]: [{
+                            range: diagnostic.range,
+                            newText: ""
+                        }]
+                    }
+                }
+            };
+        }
+        return undefined;
+    }
+
+
 }
 
 /*

--- a/src/language/model-modeling-language-validator.ts
+++ b/src/language/model-modeling-language-validator.ts
@@ -3,6 +3,7 @@ import {
     AbstractElement,
     ArithExpr,
     Attribute,
+    AttributeModifiers,
     Class,
     CReference,
     Enum,
@@ -38,6 +39,7 @@ import {
     ModelModelingLanguageAstType,
     Multiplicity,
     Package,
+    ReferenceModifiers,
     TypedVariable,
     VariableType
 } from './generated/ast.js';
@@ -84,8 +86,16 @@ export function registerValidationChecks(services: ModelModelingLanguageServices
             validator.checkMissingOppositeAnnotation,
             validator.checkNonMatchingOppositeAnnotation
         ],
+        ReferenceModifiers: [
+            validator.checkReferenceModifiersValidity,
+            validator.checkReferenceModifiersNecessity
+        ],
         Attribute: [
             validator.checkAttributeTypes
+        ],
+        AttributeModifiers: [
+            validator.checkAttributeModifiersValidity,
+            validator.checkAttributeModifiersNecessity
         ],
         Enum: [
             validator.checkUniqueEnumType
@@ -188,6 +198,10 @@ export namespace IssueCodes {
     export const InstantiationOfAbstractClass = "instantiation-of-abstract-class";
     export const InstantiationOfEnum = "instantiation-of-enum";
     export const InstantiationOfPrimitiveType = "instantiation-of-primitive-type";
+    export const UnnecessaryAttributeModifier = "unnecessary-attribute-modifier";
+    export const InvalidAttributeModifierCombination = "invalid-attribute-modifier-combination";
+    export const UnnecessaryReferenceModifier = "unnecessary-reference-modifier";
+    export const InvalidReferenceModifierCombination = "invalid-reference-modifier-combination";
 }
 
 /**
@@ -1381,6 +1395,322 @@ export class ModelModelingLanguageValidator {
                     code: IssueCodes.InstantiationOfPrimitiveType
                 })
             }
+        }
+    }
+
+    checkAttributeModifiersValidity(aMod: AttributeModifiers, accept: ValidationAcceptor) {
+        if (aMod.readonly && aMod.not_readonly) {
+            accept('error', `You have set contradictory modifiers!`, {
+                node: aMod,
+                property: 'readonly',
+                code: IssueCodes.InvalidAttributeModifierCombination
+            })
+            accept('error', `You have set contradictory modifiers!`, {
+                node: aMod,
+                property: 'not_readonly',
+                code: IssueCodes.InvalidAttributeModifierCombination
+            })
+        }
+        if (aMod.volatile && aMod.not_volatile) {
+            accept('error', `You have set contradictory modifiers!`, {
+                node: aMod,
+                property: 'volatile',
+                code: IssueCodes.InvalidAttributeModifierCombination
+            })
+            accept('error', `You have set contradictory modifiers!`, {
+                node: aMod,
+                property: 'not_volatile',
+                code: IssueCodes.InvalidAttributeModifierCombination
+            })
+        }
+        if (aMod.transient && aMod.not_transient) {
+            accept('error', `You have set contradictory modifiers!`, {
+                node: aMod,
+                property: 'transient',
+                code: IssueCodes.InvalidAttributeModifierCombination
+            })
+            accept('error', `You have set contradictory modifiers!`, {
+                node: aMod,
+                property: 'not_transient',
+                code: IssueCodes.InvalidAttributeModifierCombination
+            })
+        }
+        if (aMod.unsettable && aMod.not_unsettable) {
+            accept('error', `You have set contradictory modifiers!`, {
+                node: aMod,
+                property: 'unsettable',
+                code: IssueCodes.InvalidAttributeModifierCombination
+            })
+            accept('error', `You have set contradictory modifiers!`, {
+                node: aMod,
+                property: 'not_unsettable',
+                code: IssueCodes.InvalidAttributeModifierCombination
+            })
+        }
+        if (aMod.derived && aMod.not_derived) {
+            accept('error', `You have set contradictory modifiers!`, {
+                node: aMod,
+                property: 'derived',
+                code: IssueCodes.InvalidAttributeModifierCombination
+            })
+            accept('error', `You have set contradictory modifiers!`, {
+                node: aMod,
+                property: 'not_derived',
+                code: IssueCodes.InvalidAttributeModifierCombination
+            })
+        }
+        if (aMod.unique && aMod.not_unique) {
+            accept('error', `You have set contradictory modifiers!`, {
+                node: aMod,
+                property: 'unique',
+                code: IssueCodes.InvalidAttributeModifierCombination
+            })
+            accept('error', `You have set contradictory modifiers!`, {
+                node: aMod,
+                property: 'not_unique',
+                code: IssueCodes.InvalidAttributeModifierCombination
+            })
+        }
+        if (aMod.ordered && aMod.not_ordered) {
+            accept('error', `You have set contradictory modifiers!`, {
+                node: aMod,
+                property: 'ordered',
+                code: IssueCodes.InvalidAttributeModifierCombination
+            })
+            accept('error', `You have set contradictory modifiers!`, {
+                node: aMod,
+                property: 'not_ordered',
+                code: IssueCodes.InvalidAttributeModifierCombination
+            })
+        }
+        if (aMod.id && aMod.not_id) {
+            accept('error', `You have set contradictory modifiers!`, {
+                node: aMod,
+                property: 'id',
+                code: IssueCodes.InvalidAttributeModifierCombination
+            })
+            accept('error', `You have set contradictory modifiers!`, {
+                node: aMod,
+                property: 'not_id',
+                code: IssueCodes.InvalidAttributeModifierCombination
+            })
+        }
+    }
+
+    checkAttributeModifiersNecessity(aMod: AttributeModifiers, accept: ValidationAcceptor) {
+        if (aMod.not_readonly) {
+            accept('info', `This is the default and does not have to be specifically defined!`, {
+                node: aMod,
+                property: 'not_readonly',
+                code: IssueCodes.UnnecessaryAttributeModifier
+            })
+        }
+        if (aMod.not_volatile) {
+            accept('info', `This is the default and does not have to be specifically defined!`, {
+                node: aMod,
+                property: 'not_volatile',
+                code: IssueCodes.UnnecessaryAttributeModifier
+            })
+        }
+        if (aMod.not_transient) {
+            accept('info', `This is the default and does not have to be specifically defined!`, {
+                node: aMod,
+                property: 'not_transient',
+                code: IssueCodes.UnnecessaryAttributeModifier
+            })
+        }
+        if (aMod.not_unsettable) {
+            accept('info', `This is the default and does not have to be specifically defined!`, {
+                node: aMod,
+                property: 'unsettable',
+                code: IssueCodes.UnnecessaryAttributeModifier
+            })
+        }
+        if (aMod.not_derived) {
+            accept('info', `This is the default and does not have to be specifically defined!`, {
+                node: aMod,
+                property: 'derived',
+                code: IssueCodes.UnnecessaryAttributeModifier
+            })
+        }
+        if (aMod.unique) {
+            accept('info', `This is the default and does not have to be specifically defined!`, {
+                node: aMod,
+                property: 'unique',
+                code: IssueCodes.UnnecessaryAttributeModifier
+            })
+        }
+        if (aMod.ordered) {
+            accept('info', `This is the default and does not have to be specifically defined!`, {
+                node: aMod,
+                property: 'ordered',
+                code: IssueCodes.UnnecessaryAttributeModifier
+            })
+        }
+        if (aMod.not_id) {
+            accept('info', `This is the default and does not have to be specifically defined!`, {
+                node: aMod,
+                property: 'not_id',
+                code: IssueCodes.UnnecessaryAttributeModifier
+            })
+        }
+    }
+
+    checkReferenceModifiersValidity(rMod: ReferenceModifiers, accept: ValidationAcceptor) {
+        if (rMod.readonly && rMod.not_readonly) {
+            accept('error', `You have set contradictory modifiers!`, {
+                node: rMod,
+                property: 'readonly',
+                code: IssueCodes.InvalidReferenceModifierCombination
+            })
+            accept('error', `You have set contradictory modifiers!`, {
+                node: rMod,
+                property: 'not_readonly',
+                code: IssueCodes.InvalidReferenceModifierCombination
+            })
+        }
+        if (rMod.volatile && rMod.not_volatile) {
+            accept('error', `You have set contradictory modifiers!`, {
+                node: rMod,
+                property: 'volatile',
+                code: IssueCodes.InvalidReferenceModifierCombination
+            })
+            accept('error', `You have set contradictory modifiers!`, {
+                node: rMod,
+                property: 'not_volatile',
+                code: IssueCodes.InvalidReferenceModifierCombination
+            })
+        }
+        if (rMod.transient && rMod.not_transient) {
+            accept('error', `You have set contradictory modifiers!`, {
+                node: rMod,
+                property: 'transient',
+                code: IssueCodes.InvalidReferenceModifierCombination
+            })
+            accept('error', `You have set contradictory modifiers!`, {
+                node: rMod,
+                property: 'not_transient',
+                code: IssueCodes.InvalidReferenceModifierCombination
+            })
+        }
+        if (rMod.unsettable && rMod.not_unsettable) {
+            accept('error', `You have set contradictory modifiers!`, {
+                node: rMod,
+                property: 'unsettable',
+                code: IssueCodes.InvalidReferenceModifierCombination
+            })
+            accept('error', `You have set contradictory modifiers!`, {
+                node: rMod,
+                property: 'not_unsettable',
+                code: IssueCodes.InvalidReferenceModifierCombination
+            })
+        }
+        if (rMod.derived && rMod.not_derived) {
+            accept('error', `You have set contradictory modifiers!`, {
+                node: rMod,
+                property: 'derived',
+                code: IssueCodes.InvalidReferenceModifierCombination
+            })
+            accept('error', `You have set contradictory modifiers!`, {
+                node: rMod,
+                property: 'not_derived',
+                code: IssueCodes.InvalidReferenceModifierCombination
+            })
+        }
+        if (rMod.unique && rMod.not_unique) {
+            accept('error', `You have set contradictory modifiers!`, {
+                node: rMod,
+                property: 'unique',
+                code: IssueCodes.InvalidReferenceModifierCombination
+            })
+            accept('error', `You have set contradictory modifiers!`, {
+                node: rMod,
+                property: 'not_unique',
+                code: IssueCodes.InvalidReferenceModifierCombination
+            })
+        }
+        if (rMod.ordered && rMod.not_ordered) {
+            accept('error', `You have set contradictory modifiers!`, {
+                node: rMod,
+                property: 'ordered',
+                code: IssueCodes.InvalidReferenceModifierCombination
+            })
+            accept('error', `You have set contradictory modifiers!`, {
+                node: rMod,
+                property: 'not_ordered',
+                code: IssueCodes.InvalidReferenceModifierCombination
+            })
+        }
+        if (rMod.resolve && rMod.not_resolve) {
+            accept('error', `You have set contradictory modifiers!`, {
+                node: rMod,
+                property: 'resolve',
+                code: IssueCodes.InvalidReferenceModifierCombination
+            })
+            accept('error', `You have set contradictory modifiers!`, {
+                node: rMod,
+                property: 'not_resolve',
+                code: IssueCodes.InvalidReferenceModifierCombination
+            })
+        }
+    }
+
+    checkReferenceModifiersNecessity(rMod: ReferenceModifiers, accept: ValidationAcceptor) {
+        if (rMod.not_readonly) {
+            accept('info', `This is the default and does not have to be specifically defined!`, {
+                node: rMod,
+                property: 'not_readonly',
+                code: IssueCodes.UnnecessaryReferenceModifier
+            })
+        }
+        if (rMod.not_volatile) {
+            accept('info', `This is the default and does not have to be specifically defined!`, {
+                node: rMod,
+                property: 'not_volatile',
+                code: IssueCodes.UnnecessaryReferenceModifier
+            })
+        }
+        if (rMod.not_transient) {
+            accept('info', `This is the default and does not have to be specifically defined!`, {
+                node: rMod,
+                property: 'not_transient',
+                code: IssueCodes.UnnecessaryReferenceModifier
+            })
+        }
+        if (rMod.not_unsettable) {
+            accept('info', `This is the default and does not have to be specifically defined!`, {
+                node: rMod,
+                property: 'unsettable',
+                code: IssueCodes.UnnecessaryReferenceModifier
+            })
+        }
+        if (rMod.not_derived) {
+            accept('info', `This is the default and does not have to be specifically defined!`, {
+                node: rMod,
+                property: 'derived',
+                code: IssueCodes.UnnecessaryReferenceModifier
+            })
+        }
+        if (rMod.unique) {
+            accept('info', `This is the default and does not have to be specifically defined!`, {
+                node: rMod,
+                property: 'unique',
+                code: IssueCodes.UnnecessaryReferenceModifier
+            })
+        }
+        if (rMod.ordered) {
+            accept('info', `This is the default and does not have to be specifically defined!`, {
+                node: rMod,
+                property: 'ordered',
+                code: IssueCodes.UnnecessaryReferenceModifier
+            })
+        }
+        if (rMod.resolve) {
+            accept('info', `This is the default and does not have to be specifically defined!`, {
+                node: rMod,
+                property: 'resolve',
+                code: IssueCodes.UnnecessaryReferenceModifier
+            })
         }
     }
 }

--- a/src/language/model-modeling-language.langium
+++ b/src/language/model-modeling-language.langium
@@ -58,13 +58,21 @@ Statement:
 
 AttributeModifiers:
     readonly?='readonly' &
+    not_readonly?='!readonly' &
     volatile?='volatile' &
+    not_volatile?='!volatile' &
     transient?='transient' &
+    not_transient?='!transient' &
     unsettable?='unsettable' &
+    not_unsettable?='!unsettable' &
     derived?='derived' &
+    not_derived?='!derived' &
     unique?='unique' &
+    not_unique?='!unique' &
     ordered?='ordered' &
-    id?='id';
+    not_ordered?='!ordered' &
+    id?='id' &
+    not_id?='!id';
 
 AttributeType:
     ptype=DataType | etype=[Enum:QNAME];
@@ -74,13 +82,21 @@ Attribute:
 
 ReferenceModifiers:
     readonly?='readonly' &
+    not_readonly?='!readonly' &
     volatile?='volatile' &
+    not_volatile?='!volatile' &
     transient?='transient' &
+    not_transient?='!transient' &
     unsettable?='unsettable' &
+    not_unsettable?='!unsettable' &
     derived?='derived' &
+    not_derived?='!derived' &
     unique?='unique' &
+    not_unique?='!unique' &
     ordered?='ordered' &
-    resolve?='resolve';
+    not_ordered?='!ordered' &
+    resolve?='resolve' &
+    not_resolve?='!resolve';
 
 OppositeAnnotation:
     '@opposite' reference=[CReference:FQNAME];

--- a/src/language/model-modeling-language.langium
+++ b/src/language/model-modeling-language.langium
@@ -96,7 +96,9 @@ ReferenceModifiers:
     ordered?='ordered' &
     not_ordered?='!ordered' &
     resolve?='resolve' &
-    not_resolve?='!resolve';
+    not_resolve?='!resolve' &
+    containment?='containment' &
+    not_containment?='!containment';
 
 OppositeAnnotation:
     '@opposite' reference=[CReference:FQNAME];

--- a/src/language/serializer/mml-entity-templates.ts
+++ b/src/language/serializer/mml-entity-templates.ts
@@ -156,6 +156,7 @@ export class ClassElementModifiers {
     readonly unique: boolean = true;
     readonly ordered: boolean = true;
     readonly resolve: boolean = true;
+    readonly containment: boolean = false;
     readonly id: boolean = false;
 
 
@@ -172,6 +173,7 @@ export class ClassElementModifiers {
         this.ordered = (this.ordered || mod.ordered) && !mod.not_ordered;
         if (isReferenceModifiers(mod)) {
             this.resolve = (this.resolve || mod.resolve) && !mod.not_resolve;
+            this.containment = (this.containment || mod.containment) && !mod.not_containment;
         }
         if (isAttributeModifiers(mod)) {
             this.id = (this.id || mod.id) && !mod.not_id;

--- a/src/language/serializer/mml-entity-templates.ts
+++ b/src/language/serializer/mml-entity-templates.ts
@@ -28,7 +28,7 @@ import {MmlSerializerContext} from "./mml-serializer-context.js";
  * The metamodel is being precomputed and all references are resolved.
  */
 
-class AttributeEntity {
+export class AttributeEntity {
     readonly referenceId: string;
     readonly name: string;
     readonly type: string;
@@ -65,7 +65,7 @@ class AttributeEntity {
     }
 }
 
-class AbstractClassEntity {
+export class AbstractClassEntity {
     readonly referenceId: string;
     readonly name: string;
     readonly isAbstract: boolean;
@@ -98,7 +98,7 @@ class AbstractClassEntity {
     }
 }
 
-class ReferenceEntity {
+export class ReferenceEntity {
     readonly referenceId: string;
     readonly name: string;
     readonly multiplicity: MultiplicityEntity;
@@ -121,7 +121,7 @@ class ReferenceEntity {
     }
 }
 
-class MultiplicityEntity {
+export class MultiplicityEntity {
     readonly hasUpperBound: boolean = false;
     readonly lowerIsN: boolean = false;
     readonly lowerIsN0: boolean = false;
@@ -147,7 +147,7 @@ class MultiplicityEntity {
     }
 }
 
-class ClassElementModifiers {
+export class ClassElementModifiers {
     readonly readonly: boolean = false;
     readonly volatile: boolean = false;
     readonly transient: boolean = false;
@@ -179,7 +179,7 @@ class ClassElementModifiers {
     }
 }
 
-class EnumEntity {
+export class EnumEntity {
     readonly referenceId: string;
     readonly name: string;
     readonly type: string;
@@ -194,7 +194,7 @@ class EnumEntity {
     }
 }
 
-class EnumEntryEntity {
+export class EnumEntryEntity {
     readonly referenceId: string;
     readonly name: string;
     readonly hasDefaultValue: boolean = false;
@@ -210,7 +210,7 @@ class EnumEntryEntity {
     }
 }
 
-class PackageEntity {
+export class PackageEntity {
     readonly referenceId: string;
     readonly name: string;
     readonly abstractClasses: AbstractClassEntity[] = [];

--- a/src/language/serializer/mml-entity-templates.ts
+++ b/src/language/serializer/mml-entity-templates.ts
@@ -133,6 +133,9 @@ export class MultiplicityEntity {
 
     constructor(mult: Multiplicity | undefined) {
         if (mult == undefined) {
+            this.hasUpperBound = true;
+            this.lower = 0;
+            this.upper = 1;
             return;
         }
         this.lowerIsN = mult.mult.n;

--- a/src/language/serializer/mml-entity-templates.ts
+++ b/src/language/serializer/mml-entity-templates.ts
@@ -153,9 +153,9 @@ export class ClassElementModifiers {
     readonly transient: boolean = false;
     readonly unsettable: boolean = false;
     readonly derived: boolean = false;
-    readonly unique: boolean = false;
-    readonly ordered: boolean = false;
-    readonly resolve: boolean = false;
+    readonly unique: boolean = true;
+    readonly ordered: boolean = true;
+    readonly resolve: boolean = true;
     readonly id: boolean = false;
 
 
@@ -163,18 +163,18 @@ export class ClassElementModifiers {
         if (mod == undefined) {
             return;
         }
-        this.readonly = mod.readonly;
-        this.volatile = mod.volatile;
-        this.transient = mod.transient;
-        this.unsettable = mod.unsettable;
-        this.derived = mod.derived;
-        this.unique = mod.unique;
-        this.ordered = mod.ordered;
+        this.readonly = (this.readonly || mod.readonly) && !mod.not_readonly;
+        this.volatile = (this.volatile || mod.volatile) && !mod.not_volatile;
+        this.transient = (this.transient || mod.transient) && !mod.not_transient;
+        this.unsettable = (this.unsettable || mod.unsettable) && !mod.not_unsettable;
+        this.derived = (this.derived || mod.derived) && !mod.not_derived;
+        this.unique = (this.unique || mod.unique) && !mod.not_unique;
+        this.ordered = (this.ordered || mod.ordered) && !mod.not_ordered;
         if (isReferenceModifiers(mod)) {
-            this.resolve = mod.resolve;
+            this.resolve = (this.resolve || mod.resolve) && !mod.not_resolve;
         }
         if (isAttributeModifiers(mod)) {
-            this.id = mod.id;
+            this.id = (this.id || mod.id) && !mod.not_id;
         }
     }
 }

--- a/test/deserialization.test.ts
+++ b/test/deserialization.test.ts
@@ -1,0 +1,283 @@
+import {describe, test} from "vitest";
+import {assertDeserializer, getSerialization} from "./testutils.js";
+
+describe('Deserializer tests', () => {
+    test('Simple package', async () => {
+        const code: string = `
+package A {
+}
+`;
+        const serialization = await getSerialization(code);
+
+        assertDeserializer(serialization, code);
+    });
+
+    test('Simple package with subpackage', async () => {
+        const code: string = `
+package A {
+    package B {
+    }
+}
+`;
+        const serialization = await getSerialization(code);
+
+        assertDeserializer(serialization, code);
+    });
+
+    test('Simple package with enum', async () => {
+        const code: string = `
+package A {
+    enum B {
+        X,
+        Y = 42
+    }
+}
+`;
+        const serialization = await getSerialization(code);
+
+        assertDeserializer(serialization, code);
+    });
+
+    test('Simple package with enum and class', async () => {
+        const code: string = `
+package A {
+    enum B {
+        X,
+        Y = 42
+    }
+    class C {
+    }
+}
+        `;
+        const serialization = await getSerialization(code);
+
+        assertDeserializer(serialization, code);
+    });
+
+    test('Simple package with class 1', async () => {
+        const code: string = `
+package A {
+    class B {
+        attribute int x;
+        attribute int y = 5;
+        attribute string z = "abc" {readonly};
+    }
+}
+        `;
+        const serialization = await getSerialization(code);
+
+        assertDeserializer(serialization, code);
+    });
+
+    test('Simple package with class 2', async () => {
+        const code: string = `
+package A {
+    class B {
+        @opposite A.C::y
+        reference A.C[1] x;
+    }
+    class C {
+        @opposite A.B::x
+        reference A.B[1] y;
+    }
+}
+        `;
+        const serialization = await getSerialization(code);
+
+        assertDeserializer(serialization, code);
+    });
+
+    test('Advanced code 1', async () => {
+        const code: string = `
+package A {
+    enum C {
+        Q = true,
+        W = false
+    }
+    class B {
+        attribute bool a = true;
+        attribute bool b = false;
+        attribute string c = "ABC";
+        attribute int d = 2;
+        attribute double e = 42;
+        attribute double f = 4.2;
+        attribute A.C g = A.C::Q;
+        @opposite A.D::x
+        reference A.D x;
+        @opposite A.E::x
+        reference A.E[*] y;
+    }
+    class D {
+        @opposite A.B::x
+        reference A.B[+] x;
+    }
+    class E {
+        @opposite A.B::y
+        reference A.B[1..5] x;
+    }
+}
+        `;
+        const serialization = await getSerialization(code);
+        assertDeserializer(serialization, code);
+    });
+
+    test('References with multiplicity 1', async () => {
+        const code: string = `
+package A {
+    class B {
+        reference A.C x;
+    }
+    class C {
+        reference A.B y;
+    }
+}
+        `;
+        const serialization = await getSerialization(code);
+
+        assertDeserializer(serialization, code);
+    });
+
+    test('References with multiplicity 2', async () => {
+        const code: string = `
+package A {
+    class B {
+        reference A.C[1] x;
+    }
+    class C {
+        reference A.B y;
+    }
+}
+        `;
+        const serialization = await getSerialization(code);
+
+        assertDeserializer(serialization, code);
+    });
+
+    test('References with multiplicity 3', async () => {
+        const code: string = `
+package A {
+    class B {
+        reference A.C[5] x;
+    }
+    class C {
+        reference A.B y;
+    }
+}
+        `;
+        const serialization = await getSerialization(code);
+
+        assertDeserializer(serialization, code);
+    });
+
+    test('References with multiplicity 4', async () => {
+        const code: string = `
+package A {
+    class B {
+        reference A.C[+] x;
+    }
+    class C {
+        reference A.B y;
+    }
+}
+        `;
+        const serialization = await getSerialization(code);
+
+        assertDeserializer(serialization, code);
+    });
+
+    test('References with multiplicity 5', async () => {
+        const code: string = `
+package A {
+    class B {
+        reference A.C[*] x;
+    }
+    class C {
+        reference A.B y;
+    }
+}
+        `;
+        const serialization = await getSerialization(code);
+
+        assertDeserializer(serialization, code);
+    });
+
+    test('References with multiplicity 6', async () => {
+        const code: string = `
+package A {
+    class B {
+        reference A.C[0..+] x;
+    }
+    class C {
+        reference A.B y;
+    }
+}
+        `;
+        const serialization = await getSerialization(code);
+
+        assertDeserializer(serialization, code);
+    });
+
+    test('References with multiplicity 7', async () => {
+        const code: string = `
+package A {
+    class B {
+        reference A.C[0..5] x;
+    }
+    class C {
+        reference A.B y;
+    }
+}
+        `;
+        const serialization = await getSerialization(code);
+
+        assertDeserializer(serialization, code);
+    });
+
+    test('References with multiplicity 8', async () => {
+        const code: string = `
+package A {
+    class B {
+        reference A.C[1..5] x;
+    }
+    class C {
+        reference A.B y;
+    }
+}
+        `;
+        const serialization = await getSerialization(code);
+
+        assertDeserializer(serialization, code);
+    });
+
+    test('References with multiplicity 9', async () => {
+        const code: string = `
+package A {
+    class B {
+        reference A.C[2..5] x;
+    }
+    class C {
+        reference A.B y;
+    }
+}
+        `;
+        const serialization = await getSerialization(code);
+
+        assertDeserializer(serialization, code);
+    });
+
+    test('References with multiplicity 10', async () => {
+        const code: string = `
+package A {
+    class B {
+        reference A.C[0..*] x;
+    }
+    class C {
+        reference A.B y;
+    }
+}
+        `;
+        const serialization = await getSerialization(code);
+
+        assertDeserializer(serialization, code);
+    });
+})


### PR DESCRIPTION
The _Model Modeling Language_ was only recently introduced as a project and is still under development. However, the quasi-industry standard for the definition of metamodels is the Ecore file format. In real applications and especially for testing purposes during development, it is therefore advisable to use known and proven metamodels. However, this requires a time-consuming, manual translation from Ecore to the MML format. An automatic code generator, on the other hand, would be able to automate this process.

The corresponding pull request for the Model Modeling Language CLI is  eMoflon/model-modeling-language-cli#1

With this pull request we extend the VSCode plugin of the _Model Modeling Language_ with a command to translate metamodels in Ecore format into the MML language. For this purpose, the Model Modeling Language CLI is addressed to convert the selected Ecore file into the serialized format. The Model Modeling Language VSCode extension is then used to deserialize and generate code in MML.

**Required steps:**
- [x] Introduce a new command in the context menu of Ecore files
- [x] Introduce code templates for code generation
- [x] Implement the code generator
- [x] Introduce automatic code generator tests
- [x] Update the README.md

**Further changes in the course of this:**
- [x] Writing to nonexistent files no longer leads to errors in some cases if the parent folders do not exist
- [x] Introduction of negations for all modifiers
- [x] Correction of all default values of all modifiers
- [x] Introduction of validators and QuickFixes for modifiers to exclude invalid modifier combinations and unnecessary modifiers.
- [x] Introduction of the containment modifier