### PR TITLE
Bugfix/import scope filtering

### DIFF
--- a/src/language/model-modeling-language-code-action-provider.ts
+++ b/src/language/model-modeling-language-code-action-provider.ts
@@ -30,14 +30,22 @@ export class ModelModelingLanguageCodeActionProvider implements CodeActionProvid
 
     getCodeActions(document: LangiumDocument, params: CodeActionParams): MaybePromise<Array<Command | CodeAction>> {
         const result: CodeAction[] = [];
-        const acceptor = (ca: CodeAction | undefined) => ca && result.push(ca);
+
+        const acceptor = (ca: CodeAction | CodeAction[] | undefined) => {
+            if (Array.isArray(ca)) {
+                result.push(...ca);
+            } else {
+                result.push(ca as CodeAction)
+            }
+            return ca;
+        };
         for (const diagnostic of params.context.diagnostics) {
             this.createCodeActions(diagnostic, document, acceptor);
         }
         return result;
     }
 
-    private createCodeActions(diagnostic: Diagnostic, document: LangiumDocument, accept: (ca: CodeAction | undefined) => void): void {
+    private createCodeActions(diagnostic: Diagnostic, document: LangiumDocument, accept: (ca: CodeAction | CodeAction[] | undefined) => void): void {
         switch (diagnostic.code) {
             case IssueCodes.ImportAlreadyExists:
                 accept(this.fixDuplicateImport(diagnostic, document));

--- a/src/language/model-modeling-language-code-action-provider.ts
+++ b/src/language/model-modeling-language-code-action-provider.ts
@@ -50,6 +50,9 @@ export class ModelModelingLanguageCodeActionProvider implements CodeActionProvid
             case IssueCodes.ImportAlreadyExists:
                 accept(this.fixDuplicateImport(diagnostic, document));
                 break;
+            case IssueCodes.ImportIsMissing:
+                accept(this.fixMissingImport(diagnostic, document));
+                break;
             case IssueCodes.OppositeAnnotationMissing:
                 accept(this.fixMissingOppositeAnnotation(diagnostic, document));
                 break;
@@ -247,6 +250,27 @@ export class ModelModelingLanguageCodeActionProvider implements CodeActionProvid
         return undefined;
     }
 
+    private fixMissingImport(diagnostic: Diagnostic, document: LangiumDocument): CodeAction[] | undefined {
+        const possibleImports: string[] = diagnostic.data as string[];
+        if (possibleImports.length == 0) {
+            return undefined;
+        }
+        return possibleImports.map(pimport => {
+            return ({
+                title: `Import ${pimport}`,
+                kind: CodeActionKind.QuickFix,
+                diagnostics: [diagnostic],
+                edit: {
+                    changes: {
+                        [document.textDocument.uri]: [{
+                            range: {start: {character: 0, line: 0}, end: {character: 0, line: 0}},
+                            newText: `import "${pimport}";\n`
+                        }]
+                    }
+                }
+            } as CodeAction)
+        })
+    }
 
 }
 

--- a/src/language/model-modeling-language-scope-provider.ts
+++ b/src/language/model-modeling-language-scope-provider.ts
@@ -567,4 +567,15 @@ export class ModelModelingLanguageScopeProvider extends DefaultScopeProvider {
         }
         return combinedResult;
     }
+
+    public getScopeFixingUris(referenceType: string, referenceName: string, parentDir: URI, excludedUris: Set<string>): string[] {
+        const possibleDocs: Set<string> = new Set([...this.services.shared.workspace.LangiumDocuments.all.filter(x => !excludedUris.has(x.uri.toString())).map(x => x.uri.toString())]);
+        const importableUris: string[] = [];
+        for (const element of this.indexManager.allElements(referenceType, possibleDocs)) {
+            if (element.name == referenceName) {
+                importableUris.push(UriUtils.relative(parentDir, element.documentUri));
+            }
+        }
+        return importableUris;
+    }
 }

--- a/src/language/model-modeling-language-scope-provider.ts
+++ b/src/language/model-modeling-language-scope-provider.ts
@@ -314,8 +314,18 @@ export class ModelModelingLanguageScopeProvider extends DefaultScopeProvider {
                 }
                 return result;
             }
+        } else if (isImportAlias(context.container)) {
+            if (context.property === "ref") {
+                const iprt: Import = context.container.$container;
+                const localDocumentUri: URI = getDocument(iprt).uri;
+                const importedDocURI: URI | undefined = ModelModelingLanguageUtils.resolveRelativeModelImport(iprt.target, localDocumentUri);
+                if (importedDocURI != undefined) {
+                    return new MapScope(this.indexManager.allElements("Package", new Set([importedDocURI.toString()])));
+                }
+                return EMPTY_SCOPE;
+            }
         }
-        console.log(`[GetScope] Return super scope [Container: ${context.container.$type} (${context.container.$cstNode?.range.start.line})]`);
+        //console.log(`[GetScope] Return super scope [Container: ${context.container.$type} (${context.container.$cstNode?.range.start.line})]`);
         return super.getScope(context);
     }
 

--- a/src/language/model-modeling-language-utils.ts
+++ b/src/language/model-modeling-language-utils.ts
@@ -1,4 +1,4 @@
-import {AstNode} from "langium";
+import {AstNode, URI, UriUtils} from "langium";
 import {
     AbstractElement,
     ArithExpr,
@@ -459,5 +459,17 @@ export class ModelModelingLanguageUtils {
             })
         }
         return abstElements
+    }
+
+    public static resolveRelativeModelImport(path: string, currentUri: URI): URI | undefined {
+        if (path === undefined || path.length === 0) {
+            return undefined;
+        }
+        const dirUri = UriUtils.dirname(currentUri);
+        let grammarPath = path;
+        if (!grammarPath.endsWith('.mml')) {
+            grammarPath += '.mml';
+        }
+        return UriUtils.resolvePath(dirUri, grammarPath);
     }
 }

--- a/src/language/model-modeling-language-validator.ts
+++ b/src/language/model-modeling-language-validator.ts
@@ -663,23 +663,20 @@ export class ModelModelingLanguageValidator {
     }
 
     checkImportAliasRefsContained(ip: Import, accept: ValidationAcceptor) {
-        const importedDocURI: URI = URI.parse(ip.target);
-        ip.aliases.forEach((ipa, idx) => {
-            if (ipa.ref.$nodeDescription != undefined) {
-                if (ipa.ref.$nodeDescription.documentUri != undefined) {
-                    if (ipa.ref.$nodeDescription.documentUri.path != importedDocURI.path) {
-                        accept('error', `Package ${ipa.ref.$refText} is not defined in this document!`, {
-                            node: ip,
-                            property: 'aliases',
-                            index: idx,
-                            code: IssueCodes.AliasReferencesUnknownPackage
-                        })
-                    }
-                } else {
-                    console.error("[AliasRefsCheck] NodeDescription is undefined!");
+        const documentUri: URI = getDocument(ip).uri;
+        const importedDocURI: URI | undefined = ModelModelingLanguageUtils.resolveRelativeModelImport(ip.target, documentUri);
+        if (importedDocURI != undefined) {
+            ip.aliases.forEach((ipa, idx) => {
+                if (ipa.ref.ref == undefined || (!UriUtils.equals(getDocument(ipa.ref.ref).uri, importedDocURI))) {
+                    accept('error', `Package ${ipa.ref.$refText} is not defined in this document!`, {
+                        node: ip,
+                        property: 'aliases',
+                        index: idx,
+                        code: IssueCodes.AliasReferencesUnknownPackage
+                    })
                 }
-            }
-        });
+            });
+        }
     }
 
     checkMacroAttributeStatementType(mas: MacroAttributeStatement, accept: ValidationAcceptor) {

--- a/src/language/model-modeling-language-validator.ts
+++ b/src/language/model-modeling-language-validator.ts
@@ -651,8 +651,9 @@ export class ModelModelingLanguageValidator {
     }
 
     checkSelfImport(ip: Import, accept: ValidationAcceptor) {
-        const targetPath = ip.target;
-        if (targetPath == getDocument(ip).uri.path) {
+        const documentUri: URI = getDocument(ip).uri;
+        const importedDocURI: URI | undefined = ModelModelingLanguageUtils.resolveRelativeModelImport(ip.target, documentUri);
+        if (UriUtils.equals(documentUri, importedDocURI)) {
             accept('error', `Document imports itself!`, {
                 node: ip,
                 property: 'target',


### PR DESCRIPTION
If there are several packages with the same name, conflicts arise in Langium due to the cross-document scoping and the global exports introduced in MML. The scoper sometimes selects a package from the wrong document. If this was not imported, the validator ensures that this missing import is marked as an error.
To counteract this problem, an alias system was originally introduced in MML. In the current implementation, however, this does not work properly.

This pull request fundamentally revises the scoping of packages. Only references from imported documents are taken into account. This ensures that referenced elements from other documents lead to a linking error. At the same time, we offer the option of automatically inserting a corresponding import via a quick fix.
We are also revising the aliasing system to release aliased package names for further imports.
Finally, imports have been converted to relative path specifications at all points so that they can be transferred independently of the user and system.