### PR TITLE
Feature/gmnotebook

### DIFF
--- a/langium-config.json
+++ b/langium-config.json
@@ -14,6 +14,13 @@
         "textMate": {
             "out": "syntaxes/graph-constraint-language.tmLanguage.json"
         }
+    },{
+        "id": "graph-manipulation-language",
+        "grammar": "src/language/definition/graph-manipulation-language.langium",
+        "fileExtensions": [".gm",".gmnb"],
+        "textMate": {
+            "out": "syntaxes/graph-manipulation-language.tmLanguage.json"
+        }
     }],
     "out": "src/language/generated"
 }

--- a/langium-config.json
+++ b/langium-config.json
@@ -17,7 +17,7 @@
     },{
         "id": "graph-manipulation-language",
         "grammar": "src/language/definition/graph-manipulation-language.langium",
-        "fileExtensions": [".gm",".gmnb"],
+        "fileExtensions": [".gm"],
         "textMate": {
             "out": "syntaxes/graph-manipulation-language.tmLanguage.json"
         }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,17 @@
           ".gc"
         ],
         "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "graph-manipulation-language",
+        "aliases": [
+          "Graph Manipulation Language",
+          "graph-manipulation-language"
+        ],
+        "extensions": [
+          ".gm"
+        ],
+        "configuration": "./language-configuration.json"
       }
     ],
     "grammars": [
@@ -90,6 +101,11 @@
         "language": "graph-constraint-language",
         "scopeName": "source.graph-constraint-language",
         "path": "syntaxes/graph-constraint-language.tmLanguage.json"
+      },
+      {
+        "language": "graph-manipulation-language",
+        "scopeName": "source.graph-manipulation-language",
+        "path": "syntaxes/graph-manipulation-language.tmLanguage.json"
       }
     ],
     "notebooks": [
@@ -208,7 +224,8 @@
   "activationEvents": [
     "onLanguage:model-modeling-and-constraint-language",
     "onLanguage:model-modeling-language",
-    "onLanguage:graph-constraint-language"
+    "onLanguage:graph-constraint-language",
+    "onLanguage:graph-manipulation-language"
   ],
   "main": "./out/extension/main.cjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,17 @@
         "path": "syntaxes/graph-constraint-language.tmLanguage.json"
       }
     ],
+    "notebooks": [
+      {
+        "type": "gm-notebook",
+        "displayName": "Graph Manipulation Notebook",
+        "selector": [
+          {
+            "filenamePattern": "*.gmnb"
+          }
+        ]
+      }
+    ],
     "configuration": {
       "title": "Model Modeling Language",
       "properties": {

--- a/src/extension/gmnotebook/GMInterpreter.ts
+++ b/src/extension/gmnotebook/GMInterpreter.ts
@@ -1,11 +1,5 @@
 import {EmptyFileSystem, interruptAndCheck, LangiumDocument, MaybePromise, URI} from "langium";
-import {
-    GMStatement,
-    GraphManipulationDocument,
-    isGMChainStatement,
-    isReferencedModelStatement,
-    TargetNode
-} from "../../language/generated/ast.js";
+import {GMStatement, GraphManipulationDocument, isGMChainStatement, TargetNode} from "../../language/generated/ast.js";
 import {v4} from "uuid";
 import {GraphManipulationLanguageServices} from "../../language/graph-manipulation-language-module.js";
 import {CancellationToken, CancellationTokenSource} from "vscode-languageserver";
@@ -62,13 +56,9 @@ export class GMInterpreter {
         for (const statement of program.statements) {
             await interruptAndCheck(context.cancellationToken);
 
-            if (isReferencedModelStatement(statement)) {
-                continue;
-            } else {
-                await this.runStatement(statement, context, () => {
-                    end = true
-                });
-            }
+            await this.runStatement(statement, context, () => {
+                end = true
+            });
             if (end) {
                 break;
             }

--- a/src/extension/gmnotebook/GMInterpreter.ts
+++ b/src/extension/gmnotebook/GMInterpreter.ts
@@ -81,29 +81,27 @@ export class GMInterpreter {
         try {
             if (isGMChainStatement(element)) {
                 const req: EditChainRequest = GMProtoMapper.mapEditRequest(element) as EditChainRequest;
-                return this._modelServerConnector.clients.editClient.requestEdit(
-                    new PostEditRequest(
-                        {
-                            request: {
-                                case: "editChain",
-                                value: req
-                            }
+                const fullReq: PostEditRequest = new PostEditRequest(
+                    {
+                        request: {
+                            case: "editChain",
+                            value: req
                         }
-                    )
-                ).then(response => GMProtoMapper.processResponse(response, context));
+                    }
+                )
+                return this._modelServerConnector.clients.editClient.requestEdit(fullReq).then(response => GMProtoMapper.processResponse(fullReq, response, context));
             } else {
                 const req: EditRequest = GMProtoMapper.mapEditRequest(element) as EditRequest;
-
-                return this._modelServerConnector.clients.editClient.requestEdit(
-                    new PostEditRequest(
-                        {
-                            request: {
-                                case: "edit",
-                                value: req
-                            }
+                const fullReq: PostEditRequest = new PostEditRequest(
+                    {
+                        request: {
+                            case: "edit",
+                            value: req
                         }
-                    )
-                ).then(response => GMProtoMapper.processResponse(response, context));
+                    }
+                )
+
+                return this._modelServerConnector.clients.editClient.requestEdit(fullReq).then(response => GMProtoMapper.processResponse(fullReq, response, context));
             }
         } catch (ex) {
             if (typeof ex === "string") {

--- a/src/extension/gmnotebook/GMInterpreter.ts
+++ b/src/extension/gmnotebook/GMInterpreter.ts
@@ -1,0 +1,382 @@
+import {EmptyFileSystem, interruptAndCheck, LangiumDocument, MaybePromise, URI} from "langium";
+import {
+    GMStatement,
+    GraphManipulationDocument,
+    isCreateEdgeStatement,
+    isCreateNodeStatement,
+    isDeleteEdgeStatement,
+    isDeleteNodeStatement,
+    isReferencedModelStatement,
+    isSetAttributeStatement,
+    isValueExpr,
+    TargetNode
+} from "../../language/generated/ast.js";
+import {v4} from "uuid";
+import {GraphManipulationLanguageServices} from "../../language/graph-manipulation-language-module.js";
+import {CancellationToken, CancellationTokenSource} from "vscode-languageserver";
+import {ModelServerConnector} from "../model-server-connector.js";
+import {createMmlAndGclServices} from "../../language/main-module.js";
+import {PostEditRequest} from "../generated/de/nexus/modelserver/ModelServerEdits_pb.js";
+import {
+    EditCreateEdgeRequest,
+    EditCreateEdgeResponse,
+    EditCreateNodeAttributeAssignment,
+    EditCreateNodeRequest,
+    EditCreateNodeResponse,
+    EditDeleteEdgeRequest,
+    EditDeleteEdgeResponse,
+    EditDeleteNodeRequest,
+    EditDeleteNodeResponse,
+    EditRequest,
+    EditSetAttributeRequest,
+    EditSetAttributeResponse,
+    EditState,
+    Node
+} from "../generated/de/nexus/modelserver/ModelServerEditStatements_pb.js";
+import {ExprUtils} from "../../language/expr-utils.js";
+
+
+export class GMInterpreter {
+    private _services: GraphManipulationLanguageServices;
+    private _modelServerConnector: ModelServerConnector;
+    // after 5 seconds, the interpreter will be interrupted and call onTimeout
+    private static readonly TIMEOUT_MS = 1000 * 5;
+
+
+    constructor(modelServerConnector: ModelServerConnector) {
+        this._services = createMmlAndGclServices(EmptyFileSystem).gmlServices;
+        this._modelServerConnector = modelServerConnector;
+    }
+
+    async runInterpreter(program: string, context: InterpreterContext): Promise<void> {
+        const buildResult = await this.buildDocument(program);
+        try {
+            const gmProgram = buildResult.document.parseResult.value as GraphManipulationDocument;
+            await this.runProgram(gmProgram, context);
+        } finally {
+            await buildResult.dispose();
+        }
+    }
+
+    async runProgram(program: GraphManipulationDocument, outerContext: InterpreterContext): Promise<void> {
+        const cancellationTokenSource = new CancellationTokenSource();
+        const cancellationToken = cancellationTokenSource.token;
+
+        const timeout = setTimeout(async () => {
+            cancellationTokenSource.cancel();
+        }, GMInterpreter.TIMEOUT_MS);
+
+        const context: RunnerContext = {
+            cancellationToken,
+            timeout,
+            log: outerContext.log,
+            onStart: outerContext.onStart,
+        };
+
+        let end = false;
+
+        if (context.onStart) {
+            context.onStart();
+        }
+
+        for (const statement of program.statements) {
+            await interruptAndCheck(context.cancellationToken);
+
+            if (isReferencedModelStatement(statement)) {
+                continue;
+            } else {
+                await this.runStatement(statement, context, () => {
+                    end = true
+                });
+            }
+            if (end) {
+                break;
+            }
+        }
+    }
+
+    async runStatement(element: GMStatement, context: RunnerContext, returnFn: ReturnFunction): Promise<void> {
+        await interruptAndCheck(context.cancellationToken);
+
+        if (isSetAttributeStatement(element)) {
+            const targetNode: Node | undefined = GMInterpreter.getMappedNode(element.target);
+            if (targetNode == undefined) {
+                return Promise.reject("Unable to determine target node!");
+            }
+
+            const editSetAttrReq: EditSetAttributeRequest = new EditSetAttributeRequest();
+            editSetAttrReq.node = targetNode;
+            editSetAttrReq.attributeName = element.attr.name;
+            if (ExprUtils.isEnumValueExpression(element.val) && element.val.val.ref != undefined) {
+                editSetAttrReq.attributeValue = element.val.val.ref.name;
+            } else if (isValueExpr(element.val)) {
+                editSetAttrReq.attributeValue = `${element.val.value}`;
+            } else {
+                return Promise.reject(`Unable to assign attribute value: ${element.attr.name}`);
+            }
+
+            return this._modelServerConnector.clients.editClient.requestEdit(
+                new PostEditRequest(
+                    {
+                        request: {
+                            case: "edit",
+                            value: new EditRequest(
+                                {
+                                    request: {
+                                        case: "setAttributeRequest",
+                                        value: editSetAttrReq
+                                    }
+                                }
+                            )
+                        }
+                    }
+                )
+            ).then(response => {
+                    if (response.response.case == "edit") {
+                        if (response.response.value.response.case == "setAttributeResponse") {
+                            const editResponse: EditSetAttributeResponse = response.response.value.response.value;
+                            if (editResponse.state == EditState.SUCCESS) {
+                                context.log("Cool, success!");
+                            } else if (editResponse.state == EditState.FAILURE) {
+                                context.log(`ERROR: ${editResponse.message}`)
+                            } else {
+                                context.log("UNKNOWN ERROR!");
+                            }
+                        }
+
+                    }
+                }
+            )
+        } else if (isCreateEdgeStatement(element)) {
+            const fromNode: Node | undefined = GMInterpreter.getMappedNode(element.fromNode);
+            if (fromNode == undefined) {
+                return Promise.reject("Unable to determine target node!");
+            }
+            const toNode: Node | undefined = GMInterpreter.getMappedNode(element.toNode);
+            if (toNode == undefined) {
+                return Promise.reject("Unable to determine target node!");
+            }
+
+            const createEdgeReq: EditCreateEdgeRequest = new EditCreateEdgeRequest();
+            createEdgeReq.startNode = fromNode;
+            createEdgeReq.targetNode = toNode;
+            createEdgeReq.referenceName = element.reference.name;
+
+            return this._modelServerConnector.clients.editClient.requestEdit(
+                new PostEditRequest(
+                    {
+                        request: {
+                            case: "edit",
+                            value: new EditRequest(
+                                {
+                                    request: {
+                                        case: "createEdgeRequest",
+                                        value: createEdgeReq
+                                    }
+                                }
+                            )
+                        }
+                    }
+                )
+            ).then(response => {
+                    if (response.response.case == "edit") {
+                        if (response.response.value.response.case == "createEdgeResponse") {
+                            const editResponse: EditCreateEdgeResponse = response.response.value.response.value;
+                            if (editResponse.state == EditState.SUCCESS) {
+                                context.log("Cool, success!");
+                            } else if (editResponse.state == EditState.FAILURE) {
+                                context.log(`ERROR: ${editResponse.message}`)
+                            } else {
+                                context.log("UNKNOWN ERROR!");
+                            }
+                        }
+
+                    }
+                }
+            )
+        } else if (isDeleteEdgeStatement(element)) {
+            const fromNode: Node | undefined = GMInterpreter.getMappedNode(element.fromNode);
+            if (fromNode == undefined) {
+                return Promise.reject("Unable to determine start node!");
+            }
+            const toNode: Node | undefined = GMInterpreter.getMappedNode(element.toNode);
+            if (toNode == undefined) {
+                return Promise.reject("Unable to determine target node!");
+            }
+
+            const deleteEdgeReq: EditDeleteEdgeRequest = new EditDeleteEdgeRequest();
+            deleteEdgeReq.startNode = fromNode;
+            deleteEdgeReq.targetNode = toNode;
+            deleteEdgeReq.referenceName = element.reference.name;
+
+            return this._modelServerConnector.clients.editClient.requestEdit(
+                new PostEditRequest(
+                    {
+                        request: {
+                            case: "edit",
+                            value: new EditRequest(
+                                {
+                                    request: {
+                                        case: "deleteEdgeRequest",
+                                        value: deleteEdgeReq
+                                    }
+                                }
+                            )
+                        }
+                    }
+                )
+            ).then(response => {
+                    if (response.response.case == "edit") {
+                        if (response.response.value.response.case == "deleteEdgeResponse") {
+                            const editResponse: EditDeleteEdgeResponse = response.response.value.response.value;
+                            if (editResponse.state == EditState.SUCCESS) {
+                                context.log("Cool, success!");
+                            } else if (editResponse.state == EditState.FAILURE) {
+                                context.log(`ERROR: ${editResponse.message}`)
+                            } else {
+                                context.log("UNKNOWN ERROR!");
+                            }
+                        }
+
+                    }
+                }
+            )
+        } else if (isDeleteNodeStatement(element)) {
+            const targetNode: Node | undefined = GMInterpreter.getMappedNode(element.node);
+            if (targetNode == undefined) {
+                return Promise.reject("Unable to determine node!");
+            }
+
+            const deleteNodeReq: EditDeleteNodeRequest = new EditDeleteNodeRequest();
+            deleteNodeReq.node = targetNode;
+
+            return this._modelServerConnector.clients.editClient.requestEdit(
+                new PostEditRequest(
+                    {
+                        request: {
+                            case: "edit",
+                            value: new EditRequest(
+                                {
+                                    request: {
+                                        case: "deleteNodeRequest",
+                                        value: deleteNodeReq
+                                    }
+                                }
+                            )
+                        }
+                    }
+                )
+            ).then(response => {
+                    if (response.response.case == "edit") {
+                        if (response.response.value.response.case == "deleteNodeResponse") {
+                            const editResponse: EditDeleteNodeResponse = response.response.value.response.value;
+                            if (editResponse.state == EditState.SUCCESS) {
+                                context.log("Cool, success!");
+                                for (const removedEdge of editResponse.removedEdges) {
+                                    context.log(`[ImplicitlyRemovedEdge] (${removedEdge.fromNode?.nodeType.value ?? "UNKNOWN"})-${removedEdge.reference}->(${removedEdge.toNode?.nodeType.value ?? "UNKNOWN"})`);
+                                }
+                            } else if (editResponse.state == EditState.FAILURE) {
+                                context.log(`ERROR: ${editResponse.message}`)
+                            } else {
+                                context.log("UNKNOWN ERROR!");
+                            }
+                        }
+
+                    }
+                }
+            )
+        } else if (isCreateNodeStatement(element)) {
+            const createNodeReq: EditCreateNodeRequest = new EditCreateNodeRequest();
+            createNodeReq.tempId = element.nodeVar.name;
+            createNodeReq.nodeType = element.nodeType;
+            createNodeReq.assignments = element.assignments.map(x => {
+                const attrAssignment: EditCreateNodeAttributeAssignment = new EditCreateNodeAttributeAssignment();
+                attrAssignment.attributeName = x.attr.name;
+                attrAssignment.attributeValue = `${x.val.value}`;
+                return attrAssignment;
+            }).map(x => x as EditCreateNodeAttributeAssignment);
+
+            return this._modelServerConnector.clients.editClient.requestEdit(
+                new PostEditRequest(
+                    {
+                        request: {
+                            case: "edit",
+                            value: new EditRequest(
+                                {
+                                    request: {
+                                        case: "createNodeRequest",
+                                        value: createNodeReq
+                                    }
+                                }
+                            )
+                        }
+                    }
+                )
+            ).then(response => {
+                    if (response.response.case == "edit") {
+                        if (response.response.value.response.case == "createNodeResponse") {
+                            const editResponse: EditCreateNodeResponse = response.response.value.response.value;
+                            if (editResponse.state == EditState.SUCCESS) {
+                                context.log("Cool, success!");
+                                context.log(`Created new node with id: ${editResponse.createdNodeId}`);
+                            } else if (editResponse.state == EditState.FAILURE) {
+                                context.log(`ERROR: ${editResponse.message}`)
+                            } else {
+                                context.log("UNKNOWN ERROR!");
+                            }
+                        }
+
+                    }
+                }
+            )
+        }
+    }
+
+    private async buildDocument(code: string): Promise<BuildResult> {
+        const uuid = v4();
+        const uri = URI.parse(`memory:///${uuid}.gm`);
+        const document = this._services.shared.workspace.LangiumDocumentFactory.fromString(code, uri);
+        this._services.shared.workspace.LangiumDocuments.addDocument(document);
+        await this._services.shared.workspace.DocumentBuilder.build([document]);
+        return {
+            document,
+            dispose: async () => {
+                await this._services.shared.workspace.DocumentBuilder.update([], [uri]);
+            }
+        }
+    }
+
+    static getMappedNode(target: TargetNode): Node | undefined {
+        const targetNode = new Node();
+        if (target.nodeId != undefined) {
+            targetNode.nodeType.value = target.nodeId;
+            targetNode.nodeType.case = "nodeId";
+        } else if (target.tempNodeVar != undefined && target.tempNodeVar.ref != undefined) {
+            targetNode.nodeType.value = target.tempNodeVar.ref.name;
+            targetNode.nodeType.case = "tempId";
+        } else {
+            return undefined;
+        }
+        return targetNode;
+    }
+}
+
+interface RunnerContext {
+    cancellationToken: CancellationToken,
+    timeout: NodeJS.Timeout,
+    log: (value: unknown) => MaybePromise<void>,
+    onStart?: () => void
+}
+
+
+export interface InterpreterContext {
+    log: (value: unknown) => MaybePromise<void>,
+    onStart?: () => void,
+}
+
+interface BuildResult {
+    document: LangiumDocument
+    dispose: () => Promise<void>
+}
+
+type ReturnFunction = (value: unknown) => void;

--- a/src/extension/gmnotebook/GMNotebookKernel.ts
+++ b/src/extension/gmnotebook/GMNotebookKernel.ts
@@ -1,0 +1,61 @@
+import * as vscode from 'vscode';
+
+//import {GMInterpreter} from "./GMInterpreter.js";
+
+export class GMNotebookKernel {
+    readonly id = 'gm-kernel';
+    public readonly label = 'Graph Manipulation Kernel';
+    readonly supportedLanguages = ['graph-manipulation-language'];
+
+    private _executionOrder = 0;
+    private readonly _controller: vscode.NotebookController;
+
+    constructor() {
+
+        this._controller = vscode.notebooks.createNotebookController(this.id,
+            'gm-notebook',
+            this.label);
+
+        this._controller.supportedLanguages = this.supportedLanguages;
+        this._controller.supportsExecutionOrder = true;
+        this._controller.executeHandler = this._executeAll.bind(this);
+    }
+
+    dispose(): void {
+        this._controller.dispose();
+    }
+
+    private async _executeAll(cells: vscode.NotebookCell[]): Promise<void> {
+        for (let cell of cells) {
+            await this._doExecution(cell);
+        }
+    }
+
+    private async _doExecution(cell: vscode.NotebookCell): Promise<void> {
+        const execution = this._controller.createNotebookCellExecution(cell);
+
+        execution.executionOrder = ++this._executionOrder;
+        execution.start(Date.now());
+
+        const text = cell.document.getText();
+        await execution.clearOutput();
+        const log = async (value: unknown) => {
+            const stringValue = `${value}`;
+            await execution.appendOutput(
+                new vscode.NotebookCellOutput([vscode.NotebookCellOutputItem.text(stringValue)])
+            );
+        }
+
+        try {
+            log(text) // TODO: REMOVE
+            //await GMInterpreter.runInterpreter(text, { log });
+            execution.end(true, Date.now());
+        } catch (err) {
+            const errString = err instanceof Error ? err.message : String(err);
+            await execution.appendOutput(
+                new vscode.NotebookCellOutput([vscode.NotebookCellOutputItem.text(errString)])
+            );
+            execution.end(false, Date.now());
+        }
+    }
+}

--- a/src/extension/gmnotebook/GMNotebookSerializer.ts
+++ b/src/extension/gmnotebook/GMNotebookSerializer.ts
@@ -1,0 +1,58 @@
+import * as vscode from 'vscode';
+import {TextDecoder, TextEncoder} from "util";
+
+interface RawNotebook {
+    cells: RawNotebookCell[];
+}
+
+interface RawNotebookCell {
+    source: string[];
+    cell_type: 'code' | 'markdown';
+}
+
+export class GMNotebookSerializer implements vscode.NotebookSerializer {
+    async deserializeNotebook(
+        content: Uint8Array,
+        _token: vscode.CancellationToken
+    ): Promise<vscode.NotebookData> {
+        const contents = new TextDecoder().decode(content);
+
+        let raw: RawNotebookCell[];
+        try {
+            raw = (<RawNotebook>JSON.parse(contents)).cells;
+        } catch {
+            raw = [];
+        }
+
+        const cells = raw.map(
+            item =>
+                new vscode.NotebookCellData(
+                    item.cell_type === 'code'
+                        ? vscode.NotebookCellKind.Code
+                        : vscode.NotebookCellKind.Markup,
+                    item.source.join('\n'),
+                    item.cell_type === 'code' ? 'graph-manipulation-language' : 'markdown'
+                )
+        );
+
+        return new vscode.NotebookData(cells);
+    }
+
+    async serializeNotebook(
+        data: vscode.NotebookData,
+        _token: vscode.CancellationToken
+    ): Promise<Uint8Array> {
+        let contents: RawNotebookCell[] = [];
+
+        for (const cell of data.cells) {
+            contents.push({
+                cell_type: cell.kind === vscode.NotebookCellKind.Code ? 'code' : 'markdown',
+                source: cell.value.split(/\r?\n/g)
+            });
+        }
+
+        const notebookData: RawNotebook = {cells: contents}
+
+        return new TextEncoder().encode(JSON.stringify(notebookData));
+    }
+}

--- a/src/extension/gmnotebook/GMProtoMapper.ts
+++ b/src/extension/gmnotebook/GMProtoMapper.ts
@@ -202,7 +202,7 @@ export class GMProtoMapper {
             if (editResponse.state == EditState.SUCCESS) {
                 context.log(`[SUCCESS] Updated Node ${editRequest.node?.nodeType.value}["${editRequest.attributeName}"] -> ${editRequest.attributeValue}`);
             } else if (editResponse.state == EditState.FAILURE) {
-                throw new Error(`${editResponse.message}`)
+                context.log(`[FAILED] ${editResponse.message}`);
             } else {
                 throw new Error("UNKNOWN ERROR!");
             }
@@ -212,7 +212,7 @@ export class GMProtoMapper {
             if (editResponse.state == EditState.SUCCESS) {
                 context.log(`[SUCCESS] Created ${editRequest.startNode?.nodeType.value} -${editRequest.referenceName}-> ${editRequest.targetNode?.nodeType.value}`);
             } else if (editResponse.state == EditState.FAILURE) {
-                throw new Error(`${editResponse.message}`)
+                context.log(`[FAILED] ${editResponse.message}`);
             } else {
                 throw new Error("UNKNOWN ERROR!");
             }
@@ -222,7 +222,7 @@ export class GMProtoMapper {
             if (editResponse.state == EditState.SUCCESS) {
                 context.log(`[SUCCESS] Created new ${editRequest.nodeType}(${editRequest.assignments.map(x => `${x.attributeName} = ${x.attributeValue}`).join(", ")}) -> NEW ID: ${editResponse.createdNodeId}`);
             } else if (editResponse.state == EditState.FAILURE) {
-                throw new Error(`${editResponse.message}`)
+                context.log(`[FAILED] ${editResponse.message}`);
             } else {
                 throw new Error("UNKNOWN ERROR!");
             }
@@ -232,7 +232,7 @@ export class GMProtoMapper {
             if (editResponse.state == EditState.SUCCESS) {
                 context.log(`[SUCCESS] Deleted ${editRequest.startNode?.nodeType.value} -${editRequest.referenceName}-> ${editRequest.targetNode?.nodeType.value}`);
             } else if (editResponse.state == EditState.FAILURE) {
-                throw new Error(`${editResponse.message}`)
+                context.log(`[FAILED] ${editResponse.message}`);
             } else {
                 throw new Error("UNKNOWN ERROR!");
             }
@@ -245,7 +245,7 @@ export class GMProtoMapper {
                     context.log(`[ImplicitlyRemovedEdge] (${removedEdge.fromNode?.nodeType.value ?? "UNKNOWN"})-${removedEdge.reference}->(${removedEdge.toNode?.nodeType.value ?? "UNKNOWN"})`);
                 }
             } else if (editResponse.state == EditState.FAILURE) {
-                throw new Error(`${editResponse.message}`)
+                context.log(`[FAILED] ${editResponse.message}`);
             } else {
                 throw new Error("UNKNOWN ERROR!");
             }

--- a/src/extension/gmnotebook/GMProtoMapper.ts
+++ b/src/extension/gmnotebook/GMProtoMapper.ts
@@ -34,6 +34,7 @@ import {
 import {ExprUtils} from "../../language/expr-utils.js";
 import {GMInterpreter, RunnerContext} from "./GMInterpreter.js";
 import {PostEditRequest, PostEditResponse} from "../generated/de/nexus/modelserver/ModelServerEdits_pb.js";
+import {ExportModelRequest, ExportModelResponse} from "../generated/de/nexus/modelserver/ModelServerManagement_pb.js";
 
 export class GMProtoMapper {
 
@@ -172,6 +173,22 @@ export class GMProtoMapper {
                 }
             }
         );
+    }
+
+    public static processExportResponse(request: ExportModelRequest, response: ExportModelResponse, context: RunnerContext) {
+        if (response.success) {
+            if (request.exportWithIds) {
+                context.log(`[SUCCESS] Exported model with ids to: ${response.exportedPath}`);
+            } else {
+                context.log(`[SUCCESS] Exported model without ids to: ${response.exportedPath}`);
+            }
+        } else {
+            if (response.message.length == 0) {
+                context.log(`[FAILED] An unknown error has occurred while trying to save the model.`);
+            } else {
+                context.log(`[FAILED] ${response.message}`);
+            }
+        }
     }
 
     public static processResponse(request: PostEditRequest, response: PostEditResponse, context: RunnerContext) {

--- a/src/extension/gmnotebook/GMProtoMapper.ts
+++ b/src/extension/gmnotebook/GMProtoMapper.ts
@@ -1,0 +1,237 @@
+import {
+    CreateEdgeStatement,
+    CreateNodeStatement,
+    DeleteEdgeStatement,
+    DeleteNodeStatement,
+    GMStatement,
+    isCreateEdgeStatement,
+    isCreateNodeStatement,
+    isDeleteEdgeStatement,
+    isDeleteNodeStatement,
+    isGMChainStatement,
+    isSetAttributeStatement,
+    isValueExpr,
+    SetAttributeStatement
+} from "../../language/generated/ast.js";
+import {
+    EditChainRequest,
+    EditCreateEdgeRequest,
+    EditCreateEdgeResponse,
+    EditCreateNodeAttributeAssignment,
+    EditCreateNodeRequest,
+    EditCreateNodeResponse,
+    EditDeleteEdgeRequest,
+    EditDeleteEdgeResponse,
+    EditDeleteNodeRequest,
+    EditDeleteNodeResponse,
+    EditRequest,
+    EditResponse,
+    EditSetAttributeRequest,
+    EditSetAttributeResponse,
+    EditState,
+    Node
+} from "../generated/de/nexus/modelserver/ModelServerEditStatements_pb.js";
+import {ExprUtils} from "../../language/expr-utils.js";
+import {GMInterpreter, RunnerContext} from "./GMInterpreter.js";
+import {PostEditResponse} from "../generated/de/nexus/modelserver/ModelServerEdits_pb.js";
+
+export class GMProtoMapper {
+
+    public static mapEditRequest(element: GMStatement): EditRequest | EditChainRequest {
+        if (isSetAttributeStatement(element)) {
+            return GMProtoMapper.mapSetAttributeRequest(element);
+        } else if (isCreateEdgeStatement(element)) {
+            return GMProtoMapper.mapCreateEdgeRequest(element);
+        } else if (isDeleteEdgeStatement(element)) {
+            return GMProtoMapper.mapDeleteEdgeRequest(element);
+        } else if (isDeleteNodeStatement(element)) {
+            return GMProtoMapper.mapDeleteNodeRequest(element);
+        } else if (isCreateNodeStatement(element)) {
+            return GMProtoMapper.mapCreateNodeRequest(element);
+        } else if (isGMChainStatement(element)) {
+            const req: EditChainRequest = new EditChainRequest();
+            req.edits = element.chain.map(x => GMProtoMapper.mapEditRequest(x) as EditRequest)
+            return req;
+        } else {
+            throw new Error(`GMProtoMapper currently does not support the element: ${JSON.stringify(element)}`);
+        }
+    }
+
+    public static mapSetAttributeRequest(stmt: SetAttributeStatement): EditRequest {
+        const targetNode: Node | undefined = GMInterpreter.getMappedNode(stmt.target);
+        if (targetNode == undefined) {
+            throw new Error("Unable to determine target node!");
+        }
+
+        const editSetAttrReq: EditSetAttributeRequest = new EditSetAttributeRequest();
+        editSetAttrReq.node = targetNode;
+        editSetAttrReq.attributeName = stmt.attr.name;
+        if (ExprUtils.isEnumValueExpression(stmt.val) && stmt.val.val.ref != undefined) {
+            editSetAttrReq.attributeValue = stmt.val.val.ref.name;
+        } else if (isValueExpr(stmt.val)) {
+            editSetAttrReq.attributeValue = `${stmt.val.value}`;
+        } else {
+            throw new Error(`Unable to assign attribute value: ${stmt.attr.name}`);
+        }
+
+        return new EditRequest(
+            {
+                request: {
+                    case: "setAttributeRequest",
+                    value: editSetAttrReq
+                }
+            }
+        )
+    }
+
+    public static mapCreateNodeRequest(stmt: CreateNodeStatement): EditRequest {
+        const createNodeReq: EditCreateNodeRequest = new EditCreateNodeRequest();
+        createNodeReq.tempId = stmt.nodeVar.name;
+        createNodeReq.nodeType = stmt.nodeType;
+        createNodeReq.assignments = stmt.assignments.map(x => {
+            const attrAssignment: EditCreateNodeAttributeAssignment = new EditCreateNodeAttributeAssignment();
+            attrAssignment.attributeName = x.attr.name;
+            attrAssignment.attributeValue = `${x.val.value}`;
+            return attrAssignment;
+        }).map(x => x as EditCreateNodeAttributeAssignment);
+
+        return new EditRequest(
+            {
+                request: {
+                    case: "createNodeRequest",
+                    value: createNodeReq
+                }
+            }
+        );
+    }
+
+    public static mapDeleteNodeRequest(stmt: DeleteNodeStatement): EditRequest {
+        const targetNode: Node | undefined = GMInterpreter.getMappedNode(stmt.node);
+        if (targetNode == undefined) {
+            throw new Error("Unable to determine node!");
+        }
+
+        const deleteNodeReq: EditDeleteNodeRequest = new EditDeleteNodeRequest();
+        deleteNodeReq.node = targetNode;
+
+        return new EditRequest(
+            {
+                request: {
+                    case: "deleteNodeRequest",
+                    value: deleteNodeReq
+                }
+            }
+        );
+    }
+
+    public static mapCreateEdgeRequest(stmt: CreateEdgeStatement): EditRequest {
+        const fromNode: Node | undefined = GMInterpreter.getMappedNode(stmt.fromNode);
+        if (fromNode == undefined) {
+            throw new Error("Unable to determine target node!");
+        }
+        const toNode: Node | undefined = GMInterpreter.getMappedNode(stmt.toNode);
+        if (toNode == undefined) {
+            throw new Error("Unable to determine target node!");
+        }
+
+        const createEdgeReq: EditCreateEdgeRequest = new EditCreateEdgeRequest();
+        createEdgeReq.startNode = fromNode;
+        createEdgeReq.targetNode = toNode;
+        createEdgeReq.referenceName = stmt.reference.name;
+
+        return new EditRequest(
+            {
+                request: {
+                    case: "createEdgeRequest",
+                    value: createEdgeReq
+                }
+            }
+        );
+    }
+
+    public static mapDeleteEdgeRequest(stmt: DeleteEdgeStatement): EditRequest {
+        const fromNode: Node | undefined = GMInterpreter.getMappedNode(stmt.fromNode);
+        if (fromNode == undefined) {
+            throw new Error("Unable to determine start node!");
+        }
+        const toNode: Node | undefined = GMInterpreter.getMappedNode(stmt.toNode);
+        if (toNode == undefined) {
+            throw new Error("Unable to determine target node!");
+        }
+
+        const deleteEdgeReq: EditDeleteEdgeRequest = new EditDeleteEdgeRequest();
+        deleteEdgeReq.startNode = fromNode;
+        deleteEdgeReq.targetNode = toNode;
+        deleteEdgeReq.referenceName = stmt.reference.name;
+
+        return new EditRequest(
+            {
+                request: {
+                    case: "deleteEdgeRequest",
+                    value: deleteEdgeReq
+                }
+            }
+        );
+    }
+
+    public static processResponse(response: PostEditResponse, context: RunnerContext) {
+        if (response.response.case == "edit") {
+            GMProtoMapper._processResponse(response.response.value, context);
+        } else if (response.response.case == "editChain") {
+            response.response.value.edits.forEach(edit => GMProtoMapper._processResponse(edit, context))
+        }
+    }
+
+    private static _processResponse(response: EditResponse, context: RunnerContext) {
+        if (response.response.case == "setAttributeResponse") {
+            const editResponse: EditSetAttributeResponse = response.response.value;
+            if (editResponse.state == EditState.SUCCESS) {
+                context.log("Cool, success!");
+            } else if (editResponse.state == EditState.FAILURE) {
+                context.log(`ERROR: ${editResponse.message}`)
+            } else {
+                context.log("UNKNOWN ERROR!");
+            }
+        } else if (response.response.case == "createEdgeResponse") {
+            const editResponse: EditCreateEdgeResponse = response.response.value;
+            if (editResponse.state == EditState.SUCCESS) {
+                context.log("Cool, success!");
+            } else if (editResponse.state == EditState.FAILURE) {
+                context.log(`ERROR: ${editResponse.message}`)
+            } else {
+                context.log("UNKNOWN ERROR!");
+            }
+        } else if (response.response.case == "createNodeResponse") {
+            const editResponse: EditCreateNodeResponse = response.response.value;
+            if (editResponse.state == EditState.SUCCESS) {
+                context.log("Cool, success!");
+                context.log(`Created new node with id: ${editResponse.createdNodeId}`);
+            } else if (editResponse.state == EditState.FAILURE) {
+                context.log(`ERROR: ${editResponse.message}`)
+            } else {
+                context.log("UNKNOWN ERROR!");
+            }
+        } else if (response.response.case == "deleteEdgeResponse") {
+            const editResponse: EditDeleteEdgeResponse = response.response.value;
+            if (editResponse.state == EditState.SUCCESS) {
+                context.log("Cool, success!");
+            } else if (editResponse.state == EditState.FAILURE) {
+                context.log(`ERROR: ${editResponse.message}`)
+            } else {
+                context.log("UNKNOWN ERROR!");
+            }
+        } else if (response.response.case == "deleteNodeResponse") {
+            const editResponse: EditDeleteNodeResponse = response.response.value;
+            if (editResponse.state == EditState.SUCCESS) {
+                context.log("Cool, success!");
+                for (const removedEdge of editResponse.removedEdges) {
+                    context.log(`[ImplicitlyRemovedEdge] (${removedEdge.fromNode?.nodeType.value ?? "UNKNOWN"})-${removedEdge.reference}->(${removedEdge.toNode?.nodeType.value ?? "UNKNOWN"})`);
+                }
+            } else if (editResponse.state == EditState.FAILURE) {
+                context.log(`ERROR: ${editResponse.message}`)
+            } else {
+                context.log("UNKNOWN ERROR!");
+            }
+        }
+    }
+}

--- a/src/extension/main.ts
+++ b/src/extension/main.ts
@@ -62,6 +62,10 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
             {
                 scheme: 'file',
                 language: 'graph-constraint-language'
+            },
+            {
+                scheme: 'vscode-notebook-cell',
+                language: 'graph-manipulation-language'
             }],
         synchronize: {
             // Notify the server about file changes to files contained in the workspace

--- a/src/extension/main.ts
+++ b/src/extension/main.ts
@@ -8,6 +8,8 @@ import {DeserializeEcoreToMmlCommand} from "./commands/deserialize-ecore-to-mml-
 import {SerializeConstraintFileToFileCommand} from "./commands/serialize-constraint-file-to-file-command.js";
 import {TestModelServerCommand} from "./commands/test-model-server-command.js";
 import {ModelServerConnector} from "./model-server-connector.js";
+import {GMNotebookSerializer} from "./gmnotebook/GMNotebookSerializer.js";
+import {GMNotebookKernel} from "./gmnotebook/GMNotebookKernel.js";
 
 let client: LanguageClient;
 let logger: vscode.OutputChannel;
@@ -22,6 +24,7 @@ export function activate(context: vscode.ExtensionContext): void {
     modelServerLogger = vscode.window.createOutputChannel("Model Modeling Language Model Server")
     modelServerConnector = new ModelServerConnector(modelServerLogger);
     registerCommands(context);
+    registerGMNotebook(context);
 }
 
 // This function is called when the extension is deactivated.
@@ -85,4 +88,13 @@ function registerCommands(context: vscode.ExtensionContext) {
     new DeserializeEcoreToMmlCommand(client, logger).register(context);
     new SerializeConstraintFileToFileCommand(client, logger).register(context);
     new TestModelServerCommand(client, logger, modelServerConnector).register(context);
+}
+
+function registerGMNotebook(context: vscode.ExtensionContext) {
+    context.subscriptions.push(
+        vscode.workspace.registerNotebookSerializer(
+            'gm-notebook', new GMNotebookSerializer(), {transientOutputs: true}
+        ),
+        new GMNotebookKernel()
+    );
 }

--- a/src/extension/main.ts
+++ b/src/extension/main.ts
@@ -49,7 +49,7 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
         debug: {module: serverModule, transport: TransportKind.ipc, options: debugOptions}
     };
 
-    const fileSystemWatcher = vscode.workspace.createFileSystemWatcher('**/*.(mml|gc)');
+    const fileSystemWatcher = vscode.workspace.createFileSystemWatcher('**/*.(mml|gc|gm)');
     context.subscriptions.push(fileSystemWatcher);
 
     // Options to control the language client
@@ -62,6 +62,10 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
             {
                 scheme: 'file',
                 language: 'graph-constraint-language'
+            },
+            {
+                scheme: 'file',
+                language: 'graph-manipulation-language'
             },
             {
                 scheme: 'vscode-notebook-cell',

--- a/src/extension/main.ts
+++ b/src/extension/main.ts
@@ -99,6 +99,6 @@ function registerGMNotebook(context: vscode.ExtensionContext) {
         vscode.workspace.registerNotebookSerializer(
             'gm-notebook', new GMNotebookSerializer(), {transientOutputs: true}
         ),
-        new GMNotebookKernel()
+        new GMNotebookKernel(modelServerConnector)
     );
 }

--- a/src/extension/proto/de/nexus/modelserver/ModelServerManagement.proto
+++ b/src/extension/proto/de/nexus/modelserver/ModelServerManagement.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package de.nexus.modelserver.proto;
 
+import "google/protobuf/wrappers.proto";
+
 message GetStateRequest{
 
 }
@@ -18,11 +20,13 @@ message TerminateServerResponse{
 }
 
 message ExportModelRequest {
-  string exportName = 2;
-  string exportPath = 3;
+  google.protobuf.StringValue exportName = 1;
+  google.protobuf.StringValue exportPath = 2;
+  bool exportWithIds = 3;
 }
 
 message ExportModelResponse {
   bool success = 1;
   string message = 2;
+  string exportedPath = 3;
 }

--- a/src/language/definition/graph-manipulation-language.langium
+++ b/src/language/definition/graph-manipulation-language.langium
@@ -1,0 +1,17 @@
+grammar GraphManipulationLanguage
+import "./common"
+
+entry GraphManipulationDocument:
+    (statements+=GMStatement)*;
+
+TargetNode:
+    nodeId=NUM | tempNodeVar=[UntypedVariable:ID];
+
+GMStatement:
+    ReferencedModelStatement | SetAttributeStatement;
+
+ReferencedModelStatement:
+    'model' path=STRING ';';
+
+SetAttributeStatement:
+    'set' target=TargetNode ':' attr=[Attribute:QNAME] ('=' val=(ValueExpr | EnumValueExpr))? ';';

--- a/src/language/definition/graph-manipulation-language.langium
+++ b/src/language/definition/graph-manipulation-language.langium
@@ -8,7 +8,7 @@ TargetNode:
     nodeId=NUM | tempNodeVar=[UntypedVariable:ID];
 
 GMStatement:
-    SetAttributeStatement | CreateEdgeStatement | DeleteEdgeStatement | CreateNodeStatement | DeleteNodeStatement | GMChainStatement;
+    SetAttributeStatement | CreateEdgeStatement | DeleteEdgeStatement | CreateNodeStatement | DeleteNodeStatement | GMChainStatement | ExportStatement;
 
 GMChainStatement:
     'chain' '{' (chain+=GMStatement)* '}';
@@ -30,3 +30,6 @@ CreateEdgeStatement:
 
 DeleteEdgeStatement:
     'delete' 'edge' fromNode=TargetNode '-'reference=UntypedVariable'->' toNode=TargetNode ';';
+
+ExportStatement:
+    'export' '(' keepIds=BoolExpr (',' 'dir' '=' exportPath=STRING)? (',' 'name' '=' exportName=STRING)? ')' ';';

--- a/src/language/definition/graph-manipulation-language.langium
+++ b/src/language/definition/graph-manipulation-language.langium
@@ -8,7 +8,10 @@ TargetNode:
     nodeId=NUM | tempNodeVar=[UntypedVariable:ID];
 
 GMStatement:
-    SetAttributeStatement | CreateEdgeStatement | DeleteEdgeStatement | CreateNodeStatement | DeleteNodeStatement;
+    SetAttributeStatement | CreateEdgeStatement | DeleteEdgeStatement | CreateNodeStatement | DeleteNodeStatement | GMChainStatement;
+
+GMChainStatement:
+    'chain' '{' (chain+=GMStatement)* '}';
 
 SetAttributeStatement:
     'set' target=TargetNode ':' attr=UntypedVariable '=' val=(ValueExpr | EnumValueExpr) ';';

--- a/src/language/definition/graph-manipulation-language.langium
+++ b/src/language/definition/graph-manipulation-language.langium
@@ -8,10 +8,22 @@ TargetNode:
     nodeId=NUM | tempNodeVar=[UntypedVariable:ID];
 
 GMStatement:
-    ReferencedModelStatement | SetAttributeStatement;
-
-ReferencedModelStatement:
-    'model' path=STRING ';';
+    SetAttributeStatement | CreateEdgeStatement | DeleteEdgeStatement | CreateNodeStatement | DeleteNodeStatement;
 
 SetAttributeStatement:
-    'set' target=TargetNode ':' attr=[Attribute:QNAME] ('=' val=(ValueExpr | EnumValueExpr))? ';';
+    'set' target=TargetNode ':' attr=UntypedVariable '=' val=(ValueExpr | EnumValueExpr) ';';
+
+CreateNodeStatementAttrAssignment:
+    attr=UntypedVariable '=' val=ValueExpr;
+
+CreateNodeStatement:
+    'create' 'node' nodeType=QNAME nodeVar=UntypedVariable '(' (assignments+=CreateNodeStatementAttrAssignment (',' assignments+=CreateNodeStatementAttrAssignment)*)? ')' ';';
+
+DeleteNodeStatement:
+    'delete' 'node' node=TargetNode ';';
+
+CreateEdgeStatement:
+    'create' 'edge' fromNode=TargetNode '-'reference=UntypedVariable'->' toNode=TargetNode ';';
+
+DeleteEdgeStatement:
+    'delete' 'edge' fromNode=TargetNode '-'reference=UntypedVariable'->' toNode=TargetNode ';';

--- a/src/language/expr-utils.ts
+++ b/src/language/expr-utils.ts
@@ -5,6 +5,7 @@ import {
     Class,
     ConstraintAssertion,
     CreateNodeAttributeAssignment,
+    CreateNodeStatementAttrAssignment,
     Enum,
     EnumEntry,
     EnumValueExpr,
@@ -296,7 +297,7 @@ export class ExprUtils {
         return isVariableValueExpr(expr) && isConstraintAssertion(exprContainer);
     }
 
-    public static getExprContainer(expr: Expression): Attribute | ConstraintAssertion | FunctionArgument | ImplicitlyTypedValue | MacroAttributeStatement | PatternAttributeConstraint | EnumEntry | FixSetStatement | CreateNodeAttributeAssignment | SetAttributeStatement {
+    public static getExprContainer(expr: Expression): Attribute | ConstraintAssertion | FunctionArgument | ImplicitlyTypedValue | MacroAttributeStatement | PatternAttributeConstraint | EnumEntry | FixSetStatement | CreateNodeAttributeAssignment | SetAttributeStatement | CreateNodeStatementAttrAssignment {
         if (isExpression(expr.$container)) {
             return this.getExprContainer(expr.$container);
         }

--- a/src/language/expr-utils.ts
+++ b/src/language/expr-utils.ts
@@ -34,6 +34,7 @@ import {
     NumberExpr,
     PatternAttributeConstraint,
     QualifiedValueExpr,
+    SetAttributeStatement,
     StringExpr,
     TypedVariable,
     UntypedVariable,
@@ -295,7 +296,7 @@ export class ExprUtils {
         return isVariableValueExpr(expr) && isConstraintAssertion(exprContainer);
     }
 
-    public static getExprContainer(expr: Expression): Attribute | ConstraintAssertion | FunctionArgument | ImplicitlyTypedValue | MacroAttributeStatement | PatternAttributeConstraint | EnumEntry | FixSetStatement | CreateNodeAttributeAssignment {
+    public static getExprContainer(expr: Expression): Attribute | ConstraintAssertion | FunctionArgument | ImplicitlyTypedValue | MacroAttributeStatement | PatternAttributeConstraint | EnumEntry | FixSetStatement | CreateNodeAttributeAssignment | SetAttributeStatement {
         if (isExpression(expr.$container)) {
             return this.getExprContainer(expr.$container);
         }

--- a/src/language/expr-utils.ts
+++ b/src/language/expr-utils.ts
@@ -9,6 +9,7 @@ import {
     Enum,
     EnumEntry,
     EnumValueExpr,
+    ExportStatement,
     Expression,
     FixSetStatement,
     FunctionArgument,
@@ -297,7 +298,7 @@ export class ExprUtils {
         return isVariableValueExpr(expr) && isConstraintAssertion(exprContainer);
     }
 
-    public static getExprContainer(expr: Expression): Attribute | ConstraintAssertion | FunctionArgument | ImplicitlyTypedValue | MacroAttributeStatement | PatternAttributeConstraint | EnumEntry | FixSetStatement | CreateNodeAttributeAssignment | SetAttributeStatement | CreateNodeStatementAttrAssignment {
+    public static getExprContainer(expr: Expression): Attribute | ConstraintAssertion | FunctionArgument | ImplicitlyTypedValue | MacroAttributeStatement | PatternAttributeConstraint | EnumEntry | FixSetStatement | CreateNodeAttributeAssignment | SetAttributeStatement | CreateNodeStatementAttrAssignment | ExportStatement {
         if (isExpression(expr.$container)) {
             return this.getExprContainer(expr.$container);
         }

--- a/src/language/graph-manipulation-language-completion-provider.ts
+++ b/src/language/graph-manipulation-language-completion-provider.ts
@@ -1,0 +1,88 @@
+import {DefaultCompletionProvider, LangiumDocument} from "langium";
+import {
+    CompletionItem,
+    CompletionItemKind,
+    CompletionList,
+    CompletionParams,
+    InsertTextFormat,
+} from 'vscode-languageserver';
+
+type Suggestions = Promise<CompletionList | undefined>;
+
+/**
+ * The CompletionProvider deals with text completions. Langium allows completions of
+ * various kinds, but we currently only use code snippets to provide ready-made code
+ * snippets with fillable gaps.
+ */
+export class GraphManipulationLanguageCompletionProvider extends DefaultCompletionProvider {
+
+    override async getCompletion(document: LangiumDocument, params: CompletionParams): Suggestions {
+        const list = await super.getCompletion(document, params);
+        if (list !== undefined) {
+            const snippets: CompletionItem[] = [
+                {
+                    label: 'set',
+                    labelDetails: {
+                        detail: ' Set an attribute'
+                    },
+                    kind: CompletionItemKind.Snippet,
+                    insertText: 'set ${1:nodeId}: ${2:attribute} = ${3:value};',
+                    documentation: 'Set an attribute',
+                    insertTextFormat: InsertTextFormat.Snippet
+                },
+                {
+                    label: 'create node',
+                    labelDetails: {
+                        detail: ' Create a new node'
+                    },
+                    kind: CompletionItemKind.Snippet,
+                    insertText: 'create node ${1:class} ${2:identifier}();',
+                    documentation: 'Create a new node',
+                    insertTextFormat: InsertTextFormat.Snippet
+                },
+                {
+                    label: 'create edge',
+                    labelDetails: {
+                        detail: ' Create a new edge'
+                    },
+                    kind: CompletionItemKind.Snippet,
+                    insertText: 'create edge ${1:nodeId} -${2:reference}-> ${3:nodeId};',
+                    documentation: 'Create a new edge',
+                    insertTextFormat: InsertTextFormat.Snippet
+                },
+                {
+                    label: 'delete node',
+                    labelDetails: {
+                        detail: ' Delete a node'
+                    },
+                    kind: CompletionItemKind.Snippet,
+                    insertText: 'delete node ${1:nodeId};',
+                    documentation: 'Delete a node',
+                    insertTextFormat: InsertTextFormat.Snippet
+                },
+                {
+                    label: 'delete edge',
+                    labelDetails: {
+                        detail: ' Delete an edge'
+                    },
+                    kind: CompletionItemKind.Snippet,
+                    insertText: 'delete edge ${1:nodeId} -${2:reference}-> ${3:nodeId};',
+                    documentation: 'Delete an edge',
+                    insertTextFormat: InsertTextFormat.Snippet
+                },
+                {
+                    label: 'chain',
+                    labelDetails: {
+                        detail: ' Create a chain'
+                    },
+                    kind: CompletionItemKind.Snippet,
+                    insertText: 'chain {\n}',
+                    documentation: 'Create a chain',
+                    insertTextFormat: InsertTextFormat.Snippet
+                }
+            ];
+            list.items.push(...snippets);
+        }
+        return list;
+    }
+}

--- a/src/language/graph-manipulation-language-formatter.ts
+++ b/src/language/graph-manipulation-language-formatter.ts
@@ -1,0 +1,74 @@
+import {AbstractFormatter, AstNode, Formatting} from "langium";
+import {
+    isCreateEdgeStatement,
+    isCreateNodeStatement,
+    isDeleteEdgeStatement,
+    isDeleteNodeStatement,
+    isGMChainStatement,
+    isGraphManipulationDocument,
+    isSetAttributeStatement
+} from "./generated/ast.js";
+
+/**
+ * The Formatter deals with formatting GC code in the file. More precisely, correct
+ * line breaks and spaces between individual tokens are checked and adjusted if necessary.
+ */
+export class GraphManipulationLanguageFormatter extends AbstractFormatter {
+    protected format(node: AstNode): void {
+        if (isGraphManipulationDocument(node)) {
+            const formatter = this.getNodeFormatter(node);
+            formatter.nodes(...node.statements).prepend(Formatting.noIndent());
+        } else if (isGMChainStatement(node)) {
+            const formatter = this.getNodeFormatter(node);
+            const bracesOpen = formatter.keyword('{');
+            const bracesClose = formatter.keyword('}');
+            formatter.interior(bracesOpen, bracesClose).prepend(Formatting.indent());
+            bracesOpen.prepend(Formatting.oneSpace());
+            bracesClose.prepend(Formatting.newLine());
+        } else if (isSetAttributeStatement(node)) {
+            const formatter = this.getNodeFormatter(node);
+            formatter.keyword('set').append(Formatting.oneSpace());
+            formatter.property('target').append(Formatting.noSpace());
+            formatter.keyword(':').append(Formatting.oneSpace());
+            formatter.keyword('=').surround(Formatting.oneSpace());
+            formatter.keyword(';').prepend(Formatting.noSpace());
+        } else if (isCreateNodeStatement(node)) {
+            const formatter = this.getNodeFormatter(node);
+            formatter.keyword('create').append(Formatting.oneSpace());
+            formatter.keyword('node').append(Formatting.oneSpace());
+            formatter.property('nodeType').append(Formatting.oneSpace());
+            formatter.property('nodeVar').append(Formatting.noSpace());
+            formatter.keyword('(').append(Formatting.noSpace());
+            if (node.assignments.length > 0) {
+                formatter.keyword(')').prepend(Formatting.noSpace());
+                formatter.keywords(',').prepend(Formatting.noSpace()).append(Formatting.oneSpace());
+            }
+            for (const assignment of node.assignments) {
+                const assignmentFormatter = this.getNodeFormatter(assignment);
+                assignmentFormatter.keyword('=').surround(Formatting.oneSpace());
+            }
+            formatter.keyword(';').prepend(Formatting.noSpace());
+        } else if (isCreateEdgeStatement(node)) {
+            const formatter = this.getNodeFormatter(node);
+            formatter.keyword('create').append(Formatting.oneSpace());
+            formatter.keyword('edge').append(Formatting.oneSpace());
+            formatter.property('fromNode').append(Formatting.oneSpace());
+            formatter.property('toNode').prepend(Formatting.oneSpace());
+            formatter.property('reference').surround(Formatting.noSpace());
+            formatter.keyword(';').prepend(Formatting.noSpace());
+        } else if (isDeleteNodeStatement(node)) {
+            const formatter = this.getNodeFormatter(node);
+            formatter.keyword('delete').append(Formatting.oneSpace());
+            formatter.keyword('node').append(Formatting.oneSpace());
+            formatter.keyword(';').prepend(Formatting.noSpace());
+        } else if (isDeleteEdgeStatement(node)) {
+            const formatter = this.getNodeFormatter(node);
+            formatter.keyword('delete').append(Formatting.oneSpace());
+            formatter.keyword('edge').append(Formatting.oneSpace());
+            formatter.property('fromNode').append(Formatting.oneSpace());
+            formatter.property('toNode').prepend(Formatting.oneSpace());
+            formatter.property('reference').surround(Formatting.noSpace());
+            formatter.keyword(';').prepend(Formatting.noSpace());
+        }
+    }
+}

--- a/src/language/graph-manipulation-language-formatter.ts
+++ b/src/language/graph-manipulation-language-formatter.ts
@@ -4,6 +4,7 @@ import {
     isCreateNodeStatement,
     isDeleteEdgeStatement,
     isDeleteNodeStatement,
+    isExportStatement,
     isGMChainStatement,
     isGraphManipulationDocument,
     isSetAttributeStatement
@@ -68,6 +69,14 @@ export class GraphManipulationLanguageFormatter extends AbstractFormatter {
             formatter.property('fromNode').append(Formatting.oneSpace());
             formatter.property('toNode').prepend(Formatting.oneSpace());
             formatter.property('reference').surround(Formatting.noSpace());
+            formatter.keyword(';').prepend(Formatting.noSpace());
+        } else if (isExportStatement(node)) {
+            const formatter = this.getNodeFormatter(node);
+            formatter.keyword('export').append(Formatting.noSpace());
+            formatter.keywords(',').prepend(Formatting.noSpace()).append(Formatting.oneSpace());
+            formatter.keywords('=').surround(Formatting.noSpace());
+            formatter.keyword('(').append(Formatting.noSpace());
+            formatter.keyword(')').prepend(Formatting.noSpace());
             formatter.keyword(';').prepend(Formatting.noSpace());
         }
     }

--- a/src/language/graph-manipulation-language-module.ts
+++ b/src/language/graph-manipulation-language-module.ts
@@ -1,4 +1,5 @@
 import type {LangiumServices, Module, PartialLangiumServices} from 'langium';
+import {GraphManipulationLanguageScopeProvider} from "./graph-manipulation-language-scope-provider.js";
 
 
 /**
@@ -8,9 +9,9 @@ export type GraphManipulationLanguageAddedServices = {
     // validation: {
     //     GraphManipulationLanguageValidator: GraphManipulationLanguageValidator
     // },
-    // references:{
-    //     ScopeProvider: GraphManipulationLanguageScopeProvider
-    // },
+    references: {
+        ScopeProvider: GraphManipulationLanguageScopeProvider
+    },
     // lsp: {
     //     CompletionProvider: GraphManipulationLanguageCompletionProvider,
     //     Formatter: GraphManipulationLanguageFormatter,
@@ -33,9 +34,9 @@ export const GraphManipulationLanguageModule: Module<GraphManipulationLanguageSe
     // validation: {
     //     GraphManipulationLanguageValidator: (services) => new GraphManipulationLanguageValidator(services),
     // },
-    // references: {
-    //     ScopeProvider: (services) => new GraphManipulationLanguageScopeProvider(services),
-    // },
+    references: {
+        ScopeProvider: (services) => new GraphManipulationLanguageScopeProvider(services),
+    },
     // lsp: {
     //     CompletionProvider: (services) => new GraphManipulationLanguageCompletionProvider(services),
     //     Formatter: () => new GraphManipulationLanguageFormatter(),

--- a/src/language/graph-manipulation-language-module.ts
+++ b/src/language/graph-manipulation-language-module.ts
@@ -1,6 +1,7 @@
 import type {LangiumServices, Module, PartialLangiumServices} from 'langium';
 import {GraphManipulationLanguageScopeProvider} from "./graph-manipulation-language-scope-provider.js";
 import {GraphManipulationLanguageCompletionProvider} from "./graph-manipulation-language-completion-provider.js";
+import {GraphManipulationLanguageSemanticTokenProvider} from "./graph-manipulation-language-semantic-token-provider.js";
 
 
 /**
@@ -16,7 +17,7 @@ export type GraphManipulationLanguageAddedServices = {
     lsp: {
         CompletionProvider: GraphManipulationLanguageCompletionProvider,
         //     Formatter: GraphManipulationLanguageFormatter,
-        //     SemanticTokenProvider: GraphManipulationLanguageSemanticTokenProvider
+        SemanticTokenProvider: GraphManipulationLanguageSemanticTokenProvider
     }
 }
 
@@ -41,6 +42,6 @@ export const GraphManipulationLanguageModule: Module<GraphManipulationLanguageSe
     lsp: {
         CompletionProvider: (services) => new GraphManipulationLanguageCompletionProvider(services),
         //     Formatter: () => new GraphManipulationLanguageFormatter(),
-        //     SemanticTokenProvider: (services) => new GraphManipulationLanguageSemanticTokenProvider(services)
+        SemanticTokenProvider: (services) => new GraphManipulationLanguageSemanticTokenProvider(services)
     }
 };

--- a/src/language/graph-manipulation-language-module.ts
+++ b/src/language/graph-manipulation-language-module.ts
@@ -2,6 +2,7 @@ import type {LangiumServices, Module, PartialLangiumServices} from 'langium';
 import {GraphManipulationLanguageScopeProvider} from "./graph-manipulation-language-scope-provider.js";
 import {GraphManipulationLanguageCompletionProvider} from "./graph-manipulation-language-completion-provider.js";
 import {GraphManipulationLanguageSemanticTokenProvider} from "./graph-manipulation-language-semantic-token-provider.js";
+import {GraphManipulationLanguageFormatter} from "./graph-manipulation-language-formatter.js";
 
 
 /**
@@ -16,7 +17,7 @@ export type GraphManipulationLanguageAddedServices = {
     },
     lsp: {
         CompletionProvider: GraphManipulationLanguageCompletionProvider,
-        //     Formatter: GraphManipulationLanguageFormatter,
+        Formatter: GraphManipulationLanguageFormatter,
         SemanticTokenProvider: GraphManipulationLanguageSemanticTokenProvider
     }
 }
@@ -41,7 +42,7 @@ export const GraphManipulationLanguageModule: Module<GraphManipulationLanguageSe
     },
     lsp: {
         CompletionProvider: (services) => new GraphManipulationLanguageCompletionProvider(services),
-        //     Formatter: () => new GraphManipulationLanguageFormatter(),
+        Formatter: () => new GraphManipulationLanguageFormatter(),
         SemanticTokenProvider: (services) => new GraphManipulationLanguageSemanticTokenProvider(services)
     }
 };

--- a/src/language/graph-manipulation-language-module.ts
+++ b/src/language/graph-manipulation-language-module.ts
@@ -1,0 +1,44 @@
+import type {LangiumServices, Module, PartialLangiumServices} from 'langium';
+
+
+/**
+ * Declaration of custom services - add your own service classes here.
+ */
+export type GraphManipulationLanguageAddedServices = {
+    // validation: {
+    //     GraphManipulationLanguageValidator: GraphManipulationLanguageValidator
+    // },
+    // references:{
+    //     ScopeProvider: GraphManipulationLanguageScopeProvider
+    // },
+    // lsp: {
+    //     CompletionProvider: GraphManipulationLanguageCompletionProvider,
+    //     Formatter: GraphManipulationLanguageFormatter,
+    //     SemanticTokenProvider: GraphManipulationLanguageSemanticTokenProvider
+    // }
+}
+
+/**
+ * Union of Langium default services and your custom services - use this as constructor parameter
+ * of custom service classes.
+ */
+export type GraphManipulationLanguageServices = LangiumServices & GraphManipulationLanguageAddedServices
+
+/**
+ * Dependency injection module that overrides Langium default services and contributes the
+ * declared custom services. The Langium defaults can be partially specified to override only
+ * selected services, while the custom services must be fully specified.
+ */
+export const GraphManipulationLanguageModule: Module<GraphManipulationLanguageServices, PartialLangiumServices & GraphManipulationLanguageAddedServices> = {
+    // validation: {
+    //     GraphManipulationLanguageValidator: (services) => new GraphManipulationLanguageValidator(services),
+    // },
+    // references: {
+    //     ScopeProvider: (services) => new GraphManipulationLanguageScopeProvider(services),
+    // },
+    // lsp: {
+    //     CompletionProvider: (services) => new GraphManipulationLanguageCompletionProvider(services),
+    //     Formatter: () => new GraphManipulationLanguageFormatter(),
+    //     SemanticTokenProvider: (services) => new GraphManipulationLanguageSemanticTokenProvider(services)
+    // }
+};

--- a/src/language/graph-manipulation-language-module.ts
+++ b/src/language/graph-manipulation-language-module.ts
@@ -1,5 +1,6 @@
 import type {LangiumServices, Module, PartialLangiumServices} from 'langium';
 import {GraphManipulationLanguageScopeProvider} from "./graph-manipulation-language-scope-provider.js";
+import {GraphManipulationLanguageCompletionProvider} from "./graph-manipulation-language-completion-provider.js";
 
 
 /**
@@ -12,11 +13,11 @@ export type GraphManipulationLanguageAddedServices = {
     references: {
         ScopeProvider: GraphManipulationLanguageScopeProvider
     },
-    // lsp: {
-    //     CompletionProvider: GraphManipulationLanguageCompletionProvider,
-    //     Formatter: GraphManipulationLanguageFormatter,
-    //     SemanticTokenProvider: GraphManipulationLanguageSemanticTokenProvider
-    // }
+    lsp: {
+        CompletionProvider: GraphManipulationLanguageCompletionProvider,
+        //     Formatter: GraphManipulationLanguageFormatter,
+        //     SemanticTokenProvider: GraphManipulationLanguageSemanticTokenProvider
+    }
 }
 
 /**
@@ -37,9 +38,9 @@ export const GraphManipulationLanguageModule: Module<GraphManipulationLanguageSe
     references: {
         ScopeProvider: (services) => new GraphManipulationLanguageScopeProvider(services),
     },
-    // lsp: {
-    //     CompletionProvider: (services) => new GraphManipulationLanguageCompletionProvider(services),
-    //     Formatter: () => new GraphManipulationLanguageFormatter(),
-    //     SemanticTokenProvider: (services) => new GraphManipulationLanguageSemanticTokenProvider(services)
-    // }
+    lsp: {
+        CompletionProvider: (services) => new GraphManipulationLanguageCompletionProvider(services),
+        //     Formatter: () => new GraphManipulationLanguageFormatter(),
+        //     SemanticTokenProvider: (services) => new GraphManipulationLanguageSemanticTokenProvider(services)
+    }
 };

--- a/src/language/graph-manipulation-language-module.ts
+++ b/src/language/graph-manipulation-language-module.ts
@@ -3,15 +3,16 @@ import {GraphManipulationLanguageScopeProvider} from "./graph-manipulation-langu
 import {GraphManipulationLanguageCompletionProvider} from "./graph-manipulation-language-completion-provider.js";
 import {GraphManipulationLanguageSemanticTokenProvider} from "./graph-manipulation-language-semantic-token-provider.js";
 import {GraphManipulationLanguageFormatter} from "./graph-manipulation-language-formatter.js";
+import {GraphManipulationLanguageValidator} from "./graph-manipulation-language-validator.js";
 
 
 /**
  * Declaration of custom services - add your own service classes here.
  */
 export type GraphManipulationLanguageAddedServices = {
-    // validation: {
-    //     GraphManipulationLanguageValidator: GraphManipulationLanguageValidator
-    // },
+    validation: {
+        GraphManipulationLanguageValidator: GraphManipulationLanguageValidator
+    },
     references: {
         ScopeProvider: GraphManipulationLanguageScopeProvider
     },
@@ -34,9 +35,9 @@ export type GraphManipulationLanguageServices = LangiumServices & GraphManipulat
  * selected services, while the custom services must be fully specified.
  */
 export const GraphManipulationLanguageModule: Module<GraphManipulationLanguageServices, PartialLangiumServices & GraphManipulationLanguageAddedServices> = {
-    // validation: {
-    //     GraphManipulationLanguageValidator: (services) => new GraphManipulationLanguageValidator(services),
-    // },
+    validation: {
+        GraphManipulationLanguageValidator: (services) => new GraphManipulationLanguageValidator(services),
+    },
     references: {
         ScopeProvider: (services) => new GraphManipulationLanguageScopeProvider(services),
     },

--- a/src/language/graph-manipulation-language-scope-provider.ts
+++ b/src/language/graph-manipulation-language-scope-provider.ts
@@ -1,0 +1,38 @@
+import {DefaultScopeProvider, ReferenceInfo, Scope} from "langium";
+import {
+    CreateNodeStatement,
+    GMChainStatement,
+    isCreateEdgeStatement,
+    isCreateNodeStatement,
+    isGMChainStatement,
+    isTargetNode,
+    UntypedVariable
+} from "./generated/ast.js";
+import {ScopingUtils} from "./scoping-utils.js";
+import {GraphManipulationLanguageServices} from "./graph-manipulation-language-module.js";
+
+/**
+ * The ScopeProvider searches scopes and is used to calculate custom scopes for individual
+ * parameters that are not covered by the standard scoper.
+ */
+export class GraphManipulationLanguageScopeProvider extends DefaultScopeProvider {
+    services: GraphManipulationLanguageServices;
+
+    constructor(services: GraphManipulationLanguageServices) {
+        super(services);
+        this.services = services;
+    }
+
+
+    override getScope(context: ReferenceInfo): Scope {
+        if (isTargetNode(context.container)) {
+            if (isCreateEdgeStatement(context.container.$container) && isGMChainStatement(context.container.$container.$container)) {
+                const chainEnv: GMChainStatement = context.container.$container.$container;
+                const tempVars: UntypedVariable[] = chainEnv.chain.filter(x => isCreateNodeStatement(x)).map(x => (x as CreateNodeStatement).nodeVar);
+                return ScopingUtils.computeCustomScope(tempVars, this.descriptions, x => x.name, x => x, this.createScope);
+            }
+        }
+
+        return super.getScope(context);
+    }
+}

--- a/src/language/graph-manipulation-language-semantic-token-provider.ts
+++ b/src/language/graph-manipulation-language-semantic-token-provider.ts
@@ -1,0 +1,65 @@
+import {AbstractSemanticTokenProvider, AstNode, SemanticTokenAcceptor} from "langium";
+import {
+    isCreateEdgeStatement,
+    isCreateNodeAttributeAssignment,
+    isCreateNodeStatement,
+    isDeleteEdgeStatement,
+    isDeleteNodeStatement,
+    isGMChainStatement,
+    isSetAttributeStatement,
+    isTargetNode,
+    isUntypedVariable
+} from "./generated/ast.js";
+import {SemanticTokenTypes} from "vscode-languageserver";
+
+/**
+ * The SemanticTokenProvider deals with semantic highlighting. While syntax highlighting can
+ * be done on token level by TextMate, semantic highlighting allows even more granular and
+ * type specific options.
+ *
+ * For this purpose, a SemanticTokenType is defined for each component of each language
+ * element, which is returned to the frontend by the Language Server. Based on these
+ * types, the UI determines the color to be displayed.
+ *
+ * IMPORTANT: It is not possible to assign specific colors at this point. The final design is
+ * exclusively determined by the UI.
+ */
+export class GraphManipulationLanguageSemanticTokenProvider extends AbstractSemanticTokenProvider {
+    protected highlightElement(node: AstNode, acceptor: SemanticTokenAcceptor): void | "prune" | undefined {
+        if (isTargetNode(node)) {
+            if (node.nodeId != undefined) {
+                acceptor({node, property: "nodeId", type: SemanticTokenTypes.property});
+            }
+            if (node.tempNodeVar != undefined) {
+                acceptor({node, property: "tempNodeVar", type: SemanticTokenTypes.operator});
+            }
+        } else if (isGMChainStatement(node)) {
+            acceptor({node, keyword: "chain", type: SemanticTokenTypes.keyword});
+        } else if (isSetAttributeStatement(node)) {
+            acceptor({node, keyword: "set", type: SemanticTokenTypes.keyword});
+        } else if (isCreateNodeStatement(node)) {
+            acceptor({node, keyword: "create", type: SemanticTokenTypes.keyword});
+            acceptor({node, keyword: "node", type: SemanticTokenTypes.keyword});
+            acceptor({node, property: "nodeType", type: SemanticTokenTypes.class});
+        } else if (isCreateEdgeStatement(node)) {
+            acceptor({node, keyword: "create", type: SemanticTokenTypes.keyword});
+            acceptor({node, keyword: "edge", type: SemanticTokenTypes.keyword});
+            acceptor({node, keyword: "-", type: SemanticTokenTypes.operator});
+            acceptor({node, keyword: "->", type: SemanticTokenTypes.operator});
+        } else if (isCreateNodeAttributeAssignment(node)) {
+            acceptor({node, property: "attr", type: SemanticTokenTypes.property});
+            acceptor({node, keyword: "=", type: SemanticTokenTypes.operator});
+        } else if (isDeleteNodeStatement(node)) {
+            acceptor({node, keyword: "delete", type: SemanticTokenTypes.keyword});
+            acceptor({node, keyword: "node", type: SemanticTokenTypes.keyword});
+        } else if (isDeleteEdgeStatement(node)) {
+            acceptor({node, keyword: "delete", type: SemanticTokenTypes.keyword});
+            acceptor({node, keyword: "edge", type: SemanticTokenTypes.keyword});
+            acceptor({node, keyword: "-", type: SemanticTokenTypes.operator});
+            acceptor({node, keyword: "->", type: SemanticTokenTypes.operator});
+        } else if (isUntypedVariable(node)) {
+            acceptor({node, property: "name", type: SemanticTokenTypes.operator});
+        }
+    }
+
+}

--- a/src/language/graph-manipulation-language-semantic-token-provider.ts
+++ b/src/language/graph-manipulation-language-semantic-token-provider.ts
@@ -5,6 +5,7 @@ import {
     isCreateNodeStatement,
     isDeleteEdgeStatement,
     isDeleteNodeStatement,
+    isExportStatement,
     isGMChainStatement,
     isSetAttributeStatement,
     isTargetNode,
@@ -59,6 +60,16 @@ export class GraphManipulationLanguageSemanticTokenProvider extends AbstractSema
             acceptor({node, keyword: "->", type: SemanticTokenTypes.operator});
         } else if (isUntypedVariable(node)) {
             acceptor({node, property: "name", type: SemanticTokenTypes.operator});
+        } else if (isExportStatement(node)) {
+            acceptor({node, keyword: "export", type: SemanticTokenTypes.keyword});
+            if (node.exportPath != undefined) {
+                acceptor({node, keyword: "dir", type: SemanticTokenTypes.property});
+                acceptor({node, keyword: "=", type: SemanticTokenTypes.operator});
+            }
+            if (node.exportName != undefined) {
+                acceptor({node, keyword: "name", type: SemanticTokenTypes.property});
+                acceptor({node, keyword: "=", type: SemanticTokenTypes.operator});
+            }
         }
     }
 

--- a/src/language/graph-manipulation-language-validator.ts
+++ b/src/language/graph-manipulation-language-validator.ts
@@ -1,0 +1,95 @@
+import {ValidationAcceptor, ValidationChecks} from 'langium';
+import {
+    CreateNodeStatement,
+    GMChainStatement,
+    isCreateNodeStatement,
+    isGMChainStatement,
+    ModelModelingLanguageAstType,
+    TargetNode,
+    UntypedVariable
+} from "./generated/ast.js";
+import {GraphManipulationLanguageServices} from "./graph-manipulation-language-module.js";
+
+/**
+ * Register custom validation checks.
+ */
+export function registerValidationChecks(services: GraphManipulationLanguageServices) {
+    const registry = services.validation.ValidationRegistry;
+    const validator = services.validation.GraphManipulationLanguageValidator;
+    const checks: ValidationChecks<ModelModelingLanguageAstType> = {
+        TargetNode: [
+            validator.checkTemporaryNodeVariableInsideChain,
+            validator.checkTemporaryNodeVariableReferenceBeforeDefinition,
+        ],
+        GMChainStatement: [
+            validator.checkUniqueTemporaryNodeVariableNamesInChain
+        ]
+    };
+    registry.register(checks, validator);
+}
+
+/**
+ * Register issue codes, which are used to attach code actions.
+ */
+export namespace IssueCodes {
+    export const TemporaryNodeVariableOutsideChain = "temporary-node-variable-outside-chain";
+    export const TemporaryNodeVariableUsageBeforeDefinition = "temporary-node-variable-usage-before-definition";
+    export const TemporaryNodeVariableNameNotUnique = "temporary-node-variable-name-not-unique";
+}
+
+/**
+ * Implementation of custom validations.
+ */
+export class GraphManipulationLanguageValidator {
+    services: GraphManipulationLanguageServices;
+
+    constructor(services: GraphManipulationLanguageServices) {
+        this.services = services;
+    }
+
+    checkTemporaryNodeVariableInsideChain(tn: TargetNode, accept: ValidationAcceptor) {
+        if (!isGMChainStatement(tn.$container.$container) && tn.nodeId == undefined && tn.tempNodeVar != undefined) {
+            accept('error', `You cannot use temporary NodeVariables outside chains!`, {
+                node: tn,
+                property: 'tempNodeVar',
+                code: IssueCodes.TemporaryNodeVariableOutsideChain
+            })
+        }
+    }
+
+    checkTemporaryNodeVariableReferenceBeforeDefinition(tn: TargetNode, accept: ValidationAcceptor) {
+        if (tn.nodeId == undefined && tn.tempNodeVar != undefined && tn.tempNodeVar.ref != undefined) {
+            const referencedVariable: UntypedVariable = tn.tempNodeVar.ref;
+            if (isCreateNodeStatement(referencedVariable.$container)) {
+                const referencedDefinition: CreateNodeStatement = referencedVariable.$container;
+                const definitionIdx: number | undefined = referencedDefinition.$containerIndex;
+                const usageIdx: number | undefined = tn.$container.$containerIndex;
+                if (definitionIdx != undefined && usageIdx != undefined && usageIdx < definitionIdx) {
+                    accept('error', `Referencing NodeVariable before initialization!`, {
+                        node: tn,
+                        property: 'tempNodeVar',
+                        code: IssueCodes.TemporaryNodeVariableUsageBeforeDefinition
+                    })
+                }
+            } else {
+                throw new Error(`Unexpectedly encountered reference to node of type ${referencedVariable.$container.$type}`);
+            }
+        }
+    }
+
+    checkUniqueTemporaryNodeVariableNamesInChain(cn: GMChainStatement, accept: ValidationAcceptor) {
+        const knownNames: Set<string> = new Set();
+        cn.chain.filter(x => isCreateNodeStatement(x)).map(x => x as CreateNodeStatement).forEach(stmt => {
+            if (knownNames.has(stmt.nodeVar.name)) {
+                accept('error', `NodeVariableName not unique inside chain!`, {
+                    node: stmt,
+                    property: 'nodeVar',
+                    code: IssueCodes.TemporaryNodeVariableNameNotUnique
+                })
+            } else {
+                knownNames.add(stmt.nodeVar.name);
+            }
+        });
+    }
+
+}

--- a/src/language/main-module.ts
+++ b/src/language/main-module.ts
@@ -27,6 +27,7 @@ import {
     GraphManipulationLanguageModule,
     GraphManipulationLanguageServices
 } from "./graph-manipulation-language-module.js";
+import {MainServiceRegistry} from "./main-service-registry.js";
 
 /**
  * Create the full set of services required by Langium.
@@ -53,6 +54,10 @@ export function createMmlAndGclServices(context: DefaultSharedModuleContext): {
         createDefaultSharedModule(context),
         ModelModelingLanguageGeneratedSharedModule
     );
+
+    // register custom ServiceRegistry to handle VSCode Notebooks
+    shared.ServiceRegistry = new MainServiceRegistry();
+
     const mmlServices = inject(
         createDefaultModule({shared}),
         ModelModelingLanguageGeneratedModule,

--- a/src/language/main-module.ts
+++ b/src/language/main-module.ts
@@ -21,6 +21,9 @@ import {
     registerValidationChecks as registerGraphConstraintLanguageValidations
 } from "./graph-constraint-language-validator.js";
 import {
+    registerValidationChecks as registerGraphManipulationLanguageValidations
+} from "./graph-manipulation-language-validator.js";
+import {
     GraphManipulationLanguageModule,
     GraphManipulationLanguageServices
 } from "./graph-manipulation-language-module.js";
@@ -70,6 +73,6 @@ export function createMmlAndGclServices(context: DefaultSharedModuleContext): {
     shared.ServiceRegistry.register(gmlServices);
     registerModelModelingLanguageValidations(mmlServices);
     registerGraphConstraintLanguageValidations(gclServices);
-    //registerGraphManipulationLanguageValidations(gmlServices);
+    registerGraphManipulationLanguageValidations(gmlServices);
     return {shared, mmlServices, gclServices, gmlServices};
 }

--- a/src/language/main-module.ts
+++ b/src/language/main-module.ts
@@ -8,6 +8,7 @@ import type {DefaultSharedModuleContext, LangiumSharedServices} from 'langium';
 import {createDefaultModule, createDefaultSharedModule, inject} from 'langium';
 import {
     GraphConstraintLanguageGeneratedModule,
+    GraphManipulationLanguageGeneratedModule,
     ModelModelingLanguageGeneratedModule,
     ModelModelingLanguageGeneratedSharedModule,
 } from './generated/module.js';
@@ -19,6 +20,10 @@ import {
 import {
     registerValidationChecks as registerGraphConstraintLanguageValidations
 } from "./graph-constraint-language-validator.js";
+import {
+    GraphManipulationLanguageModule,
+    GraphManipulationLanguageServices
+} from "./graph-manipulation-language-module.js";
 
 /**
  * Create the full set of services required by Langium.
@@ -38,7 +43,8 @@ import {
 export function createMmlAndGclServices(context: DefaultSharedModuleContext): {
     shared: LangiumSharedServices,
     mmlServices: ModelModelingLanguageServices,
-    gclServices: GraphConstraintLanguageServices
+    gclServices: GraphConstraintLanguageServices,
+    gmlServices: GraphManipulationLanguageServices
 } {
     const shared = inject(
         createDefaultSharedModule(context),
@@ -54,9 +60,16 @@ export function createMmlAndGclServices(context: DefaultSharedModuleContext): {
         GraphConstraintLanguageGeneratedModule,
         GraphConstraintLanguageModule
     );
+    const gmlServices = inject(
+        createDefaultModule({shared}),
+        GraphManipulationLanguageGeneratedModule,
+        GraphManipulationLanguageModule
+    );
     shared.ServiceRegistry.register(mmlServices);
     shared.ServiceRegistry.register(gclServices);
+    shared.ServiceRegistry.register(gmlServices);
     registerModelModelingLanguageValidations(mmlServices);
     registerGraphConstraintLanguageValidations(gclServices);
-    return {shared, mmlServices, gclServices};
+    //registerGraphManipulationLanguageValidations(gmlServices);
+    return {shared, mmlServices, gclServices, gmlServices};
 }

--- a/src/language/main-service-registry.ts
+++ b/src/language/main-service-registry.ts
@@ -1,0 +1,23 @@
+import {DefaultServiceRegistry, LangiumServices, URI, UriUtils} from "langium";
+
+export class MainServiceRegistry extends DefaultServiceRegistry {
+    override getServices(uri: URI): LangiumServices {
+        if (this.singleton !== undefined) {
+            return this.singleton;
+        }
+        if (this.map === undefined) {
+            throw new Error('The service registry is empty. Use `register` to register the services of a language.');
+        }
+        let ext = UriUtils.extname(uri);
+
+        if (ext == ".gmnb") {
+            ext = ".gm";
+        }
+
+        const services = this.map[ext];
+        if (!services) {
+            throw new Error(`The service registry contains no services for the extension '${ext}'.`);
+        }
+        return services;
+    }
+}


### PR DESCRIPTION
As part of the Graph Constraint Language, we want to give users a way to make in-memory changes to the model at runtime. For this purpose, the ModelServer has the Edit interface, for which we add a connection to VSCode with this pull request.

This pull request introduces the Graph Manipulation Language, which allows the ModelServerEdit interface to be addressed. The language therefore has structures for the following operations:
* Changing a node attribute
* Adding and removing nodes
* Adding and removing edges
* Exporting the current model
* Chain statements to execute several operations in a bundle

With GraphManipulationNotebooks based on the VSCode Notebooks API, we enable traceable and reproducible model manipulations by documenting the operations in Markdown cells.