### PR TITLE
Feature/constraint language empty matches

### DIFF
--- a/src/extension/proto/de/nexus/modelserver/ModelServerConstraints.proto
+++ b/src/extension/proto/de/nexus/modelserver/ModelServerConstraints.proto
@@ -54,6 +54,7 @@ message FixProposal {
 message FixMatch {
   repeated FixVariant variants = 1;
   repeated MatchNode nodes = 2;
+  bool emptyMatch = 3;
 }
 
 message MatchNode {

--- a/src/extension/webview/components/FixProposalOption.tsx
+++ b/src/extension/webview/components/FixProposalOption.tsx
@@ -61,6 +61,10 @@ export function FixProposalOption(props: { proposal: FixProposal; }) {
         const matches: FixMatch[] = proposal.matches;
 
         for (const match of matches) {
+            if (match.emptyMatch) {
+                continue;
+            }
+
             const selectedVariant: FixVariant | undefined = match.variants.at(idx);
 
             if (selectedVariant == undefined) {

--- a/src/extension/webview/components/MatchFixVariant.css
+++ b/src/extension/webview/components/MatchFixVariant.css
@@ -19,10 +19,6 @@
     margin-right: 0.5em;
 }
 
-.ms-match-fix-variant-button-run {
-
-}
-
 .ms-match-fix-variant-content-info-statement-wrapper {
     padding: 0.5em;
     border: 1px solid goldenrod;

--- a/src/extension/webview/components/MatchFixVariant.tsx
+++ b/src/extension/webview/components/MatchFixVariant.tsx
@@ -16,10 +16,11 @@ import "./MatchFixVariant.css"
 export function MatchFixVariant(props: {
     idx: number;
     variant: FixVariant;
+    variantForEmptyMatch: boolean;
     selectVariantCb: Function;
     selectVariantForAllCb: Function;
 }) {
-    let {idx, variant, selectVariantCb, selectVariantForAllCb} = props;
+    let {idx, variant, variantForEmptyMatch, selectVariantCb, selectVariantForAllCb} = props;
 
     const [fixVariantDetailsExpanded, setFixVariantDetailsExpanded] = React.useState(false);
     const [detailsIcon, setDetailsIcon] = React.useState("codicon codicon-diff-added");
@@ -57,17 +58,15 @@ export function MatchFixVariant(props: {
                     </div>
                     <div className="ms-match-fix-variant-header-button-wrapper wrapper-column">
                         <div className="wrapper-row">
-                            {
-                                <div className="ms-match-fix-variant-button-run">
-                                    <VSCodeButton appearance="icon" onClick={() => selectVariantCb(idx)}>
-                                        <i className="codicon codicon-run" style={{color: iconColor}}></i>
-                                    </VSCodeButton>
-                                    <VSCodeButton appearance="icon"
-                                                  onClick={() => selectVariantForAllCb(idx)}>
-                                        <i className="codicon codicon-run-all" style={{color: iconColor}}></i>
-                                    </VSCodeButton>
-                                </div>
-                            }
+                            <VSCodeButton appearance="icon" onClick={() => selectVariantCb(idx)}>
+                                <i className="codicon codicon-run" style={{color: iconColor}}></i>
+                            </VSCodeButton>
+                            {!variantForEmptyMatch && (
+                                <VSCodeButton appearance="icon"
+                                              onClick={() => selectVariantForAllCb(idx)}>
+                                    <i className="codicon codicon-run-all" style={{color: iconColor}}></i>
+                                </VSCodeButton>
+                            )}
                             <VSCodeButton appearance="icon" onClick={toggleDetails}>
                                 <i className={detailsIcon} style={{color: iconColor}}></i>
                             </VSCodeButton>

--- a/src/extension/webview/components/MatchInstance.css
+++ b/src/extension/webview/components/MatchInstance.css
@@ -2,6 +2,14 @@
 
 }
 
+.ms-match-instance-wrapper:first-child {
+    margin-top: 0.25em;
+}
+
+.ms-match-instance-wrapper:not(:first-child) {
+    margin-top: 1em;
+}
+
 .ms-match-instance-header {
     /*noinspection CssUnresolvedCustomProperty*/
     background-color: var(--vscode-input-border);

--- a/src/extension/webview/components/MatchInstance.tsx
+++ b/src/extension/webview/components/MatchInstance.tsx
@@ -36,7 +36,7 @@ export function MatchInstance(props: {
         return (
             <>
                 <MatchFixVariant idx={idx} key={`variant-${idx}`}
-                                 variant={variant}
+                                 variant={variant} variantForEmptyMatch={match.emptyMatch}
                                  selectVariantCb={innerSelectVariantCb} selectVariantForAllCb={selectVariantForAllCb}/>
                 {idx < maxIdx && (
                     <VSCodeDivider className="ms-match-instance-variant-divider" key={`variant-divider-${idx}`}/>)}

--- a/src/extension/webview/components/MatchInstance.tsx
+++ b/src/extension/webview/components/MatchInstance.tsx
@@ -47,19 +47,23 @@ export function MatchInstance(props: {
     const matchVariants = match.variants.map((x, idx) => variantProvider(x, idx, match.variants.length - 1));
     const matchHasVariants: boolean = matchVariants.length > 0;
 
+    const matchTagText: string = match.emptyMatch ? "Empty Match" : "Match";
+
     return (
         <>
             <div className="ms-match-instance-wrapper wrapper-column">
                 <div className="ms-match-instance-header wrapper-row">
                     <div className="ms-match-instance-header-tag-wrapper wrapper-column">
-                        <VSCodeTag>Match</VSCodeTag>
+                        <VSCodeTag>{matchTagText}</VSCodeTag>
                     </div>
                     <div className="ms-match-instance-header-text-wrapper wrapper-column">
                     </div>
                     <div className="ms-match-instance-header-button-wrapper wrapper-column">
-                        <VSCodeButton appearance="icon" onClick={toggleDetails}>
-                            <i className={detailsIcon} style={{color: iconColor}}></i>
-                        </VSCodeButton>
+                        {!match.emptyMatch && (
+                            <VSCodeButton appearance="icon" onClick={toggleDetails}>
+                                <i className={detailsIcon} style={{color: iconColor}}></i>
+                            </VSCodeButton>
+                        )}
                     </div>
                 </div>
                 <div className="wrapper-row">

--- a/src/extension/webview/components/ModelServerEvaluationSummary.tsx
+++ b/src/extension/webview/components/ModelServerEvaluationSummary.tsx
@@ -58,7 +58,8 @@ export function ModelServerEvaluationSummary() {
                     <span className="ms-eval-summary-subtitle">{summaryText}</span>
                 </div>
                 <div className="ms-eval-summary-button-wrapper">
-                    <VSCodeButton onClick={requestConstraints}>Evaluate Constraints</VSCodeButton>
+                    <VSCodeButton onClick={requestConstraints} disabled={evalContext.loadState == "loading"}>Evaluate
+                        Constraints</VSCodeButton>
                 </div>
             </div>
         </>

--- a/src/language/constraints/gcl-entity-templates.ts
+++ b/src/language/constraints/gcl-entity-templates.ts
@@ -319,12 +319,14 @@ export class ConstraintPatternDeclarationEntity {
 export class FixContainerEntity {
     readonly isEnableContainer: boolean;
     readonly fixTitle: string;
+    readonly isEmptyMatchFix: boolean;
     readonly statements: FixStatementEntity[];
 
 
     constructor(fixContainer: FixContainer, resolver: GclReferenceStorage) {
         this.isEnableContainer = isEnableFixContainer(fixContainer) && !isDisableFixContainer(fixContainer)
         this.fixTitle = fixContainer.fixTitle ?? `QuickFix ${fixContainer.$containerIndex ?? "UNKNOWN"}`;
+        this.isEmptyMatchFix = fixContainer.emptyFix;
         this.statements = fixContainer.fixStatements.map(x => {
             if (isFixInfoStatement(x)) {
                 return new FixInfoStatementEntity(x);

--- a/src/language/definition/graph-constraint-language.langium
+++ b/src/language/definition/graph-constraint-language.langium
@@ -68,10 +68,10 @@ FixContainer:
     EnableFixContainer | DisableFixContainer;
 
 EnableFixContainer:
-    'enable' ('(' fixTitle=STRING ')')? '{' (fixStatements+=FixStatement)* '}';
+    (emptyFix?='empty')? 'enable' ('(' fixTitle=STRING ')')? '{' (fixStatements+=FixStatement)* '}';
 
 DisableFixContainer:
-    'disable' ('(' fixTitle=STRING ')')? '{' (fixStatements+=FixStatement)* '}';
+    (emptyFix?='empty')? 'disable' ('(' fixTitle=STRING ')')? '{' (fixStatements+=FixStatement)* '}';
 
 FixStatement:
     FixInfoStatement | FixSetStatement | FixDeleteNodeStatement | FixDeleteEdgeStatement | FixCreateNodeStatement | FixCreateEdgeStatement;

--- a/src/language/graph-constraint-language-formatter.ts
+++ b/src/language/graph-constraint-language-formatter.ts
@@ -143,6 +143,9 @@ export class GraphConstraintLanguageFormatter extends AbstractFormatter {
                 formatter.keyword('(').prepend(Formatting.noSpace());
                 formatter.property('fixTitle').surround(Formatting.noSpace());
             }
+            if (node.emptyFix) {
+                formatter.keyword('empty').append(Formatting.oneSpace());
+            }
         } else if (isDisableFixContainer(node)) {
             const formatter = this.getNodeFormatter(node);
             const bracesOpen = formatter.keyword('{');
@@ -150,6 +153,13 @@ export class GraphConstraintLanguageFormatter extends AbstractFormatter {
             formatter.interior(bracesOpen, bracesClose).prepend(Formatting.indent());
             bracesOpen.prepend(Formatting.oneSpace());
             bracesClose.prepend(Formatting.newLine());
+            if (node.fixTitle != undefined) {
+                formatter.keyword('(').prepend(Formatting.noSpace());
+                formatter.property('fixTitle').surround(Formatting.noSpace());
+            }
+            if (node.emptyFix) {
+                formatter.keyword('empty').append(Formatting.oneSpace());
+            }
         } else if (isFixInfoStatement(node)) {
             const formatter = this.getNodeFormatter(node);
             formatter.property('msg').prepend(Formatting.oneSpace());

--- a/src/language/graph-constraint-language-semantic-token-provider.ts
+++ b/src/language/graph-constraint-language-semantic-token-provider.ts
@@ -108,8 +108,14 @@ export class GraphConstraintLanguageSemanticTokenProvider extends AbstractSemant
             acceptor({node, keyword: "assert", type: SemanticTokenTypes.keyword});
         } else if (isEnableFixContainer(node)) {
             acceptor({node, keyword: "enable", type: SemanticTokenTypes.keyword});
+            if (node.emptyFix) {
+                acceptor({node, keyword: "empty", type: SemanticTokenTypes.keyword});
+            }
         } else if (isDisableFixContainer(node)) {
             acceptor({node, keyword: "disable", type: SemanticTokenTypes.keyword});
+            if (node.emptyFix) {
+                acceptor({node, keyword: "empty", type: SemanticTokenTypes.keyword});
+            }
         } else if (isFixInfoStatement(node)) {
             acceptor({node, keyword: "info", type: SemanticTokenTypes.keyword});
         } else if (isFixSetStatement(node)) {


### PR DESCRIPTION
FixVariants are fundamentally linked to matches, which means that we calculate all possible (predefined) variants for all matches. However, there are no matches for Enable Fixes, as these are to be generated by the fix. So far, this has meant that no enable fixes have been made available to users.

In this pull request, we extend the GCL syntax to include the `empty` keyword, which can be used to explicitly define a fix variant for empty matches. At the same time, we use the validator to ensure that the `empty` keyword cannot be used for disable fixes.

An `empty` fix can only contain independent fix statements, including info statements, createNode statements and createEdge statements, as long as no edges are to be drawn to existing elements.

Empty matches are explicitly listed in the ModelServer evaluation, although no run-all is supported for these.