### PR TITLE
Feature/constraint language template strings

### DIFF
--- a/src/language/constraints/gcl-entity-templates.ts
+++ b/src/language/constraints/gcl-entity-templates.ts
@@ -38,6 +38,8 @@ import {
     isNodeConstraintAnnotation,
     isPattern,
     isPatternObject,
+    isQualifiedValueExpr,
+    isTemplateLiteral,
     isTitleAnnotation,
     isUnaryExpression,
     isValueExpr,
@@ -232,6 +234,18 @@ export class BinaryExpressionEntity {
                 throw new Error(`Unknown pattern node "${patternObjName}"`);
             }
             return new PrimaryExpressionEntity("", resolver, ModelModelingLanguageUtils.getQualifiedClassName(attr.$container, attr.$container.name), attr.name, resolver.getNodeReferenceId(node), true, false);
+        }
+        if (isQualifiedValueExpr(expr) && expr.val.ref != undefined) {
+            const qValueContainer = ExprUtils.getExprContainer(expr);
+            if (isTemplateLiteral(qValueContainer) && isFixInfoStatement(qValueContainer.$container)) {
+                const attr: Attribute = expr.val.ref as Attribute;
+                const separatedAttributeAccess: string[] = expr.val.$refText.split(".");
+                if (separatedAttributeAccess.length != 2) {
+                    throw new Error(`Broke AttributeInvocation "${expr.val.$refText}" but received ${separatedAttributeAccess.length} parts!`)
+                }
+                const patternObjName: string = separatedAttributeAccess.at(0) as string;
+                return new PrimaryExpressionEntity("", resolver, ModelModelingLanguageUtils.getQualifiedClassName(attr.$container, attr.$container.name), attr.name, patternObjName, true, false);
+            }
         }
         throw new Error(`Missing serializer in BinaryExpressionEntity.generateChild() -> ${expr.$type}`);
     }

--- a/src/language/definition/common.langium
+++ b/src/language/definition/common.langium
@@ -160,6 +160,38 @@ FunctionVariable:
 VariableType:
     type=[AbstractElement:QNAME] | dtype=DataType;
 
+TemplateLiteral:
+    // Either just the full content
+    content+=TEMPLATE_LITERAL_FULL |
+    // Or template literal parts with expressions in between
+    (
+        content+=TEMPLATE_LITERAL_START
+        content+=Expression?
+        (
+            content+=TEMPLATE_LITERAL_MIDDLE
+            content+=Expression?
+        )*
+        content+=TEMPLATE_LITERAL_END
+    )
+;
+
+terminal TEMPLATE_LITERAL_FULL:
+    "'" IN_TEMPLATE_LITERAL* "'";
+
+terminal TEMPLATE_LITERAL_START:
+    "'" IN_TEMPLATE_LITERAL* '{';
+
+terminal TEMPLATE_LITERAL_MIDDLE:
+    '}' IN_TEMPLATE_LITERAL* '{';
+
+terminal TEMPLATE_LITERAL_END:
+    '}' IN_TEMPLATE_LITERAL* "'";
+
+// '{{' is handled in a special way so we can escape normal '{' characters
+// "''" is doing the same for the '`' character
+terminal fragment IN_TEMPLATE_LITERAL:
+    /[^{']|{{|''/;
+
 hidden terminal WS: /\s+/;
 terminal DOUBLE returns number: /-?\d+\.\d+/;
 terminal NUM returns number: /-?\d+/;

--- a/src/language/definition/graph-constraint-language.langium
+++ b/src/language/definition/graph-constraint-language.langium
@@ -77,7 +77,7 @@ FixStatement:
     FixInfoStatement | FixSetStatement | FixDeleteNodeStatement | FixDeleteEdgeStatement | FixCreateNodeStatement | FixCreateEdgeStatement;
 
 FixInfoStatement:
-    'info' msg=STRING ';';
+    'info' (msg=STRING | templateMsg=TemplateLiteral) ';';
 
 FixSetStatement:
     'set' attr=[Attribute:QNAME] ('=' val=(ValueExpr | EnumValueExpr))? ';';

--- a/src/language/expr-utils.ts
+++ b/src/language/expr-utils.ts
@@ -38,6 +38,7 @@ import {
     QualifiedValueExpr,
     SetAttributeStatement,
     StringExpr,
+    TemplateLiteral,
     TypedVariable,
     UntypedVariable,
     Variable,
@@ -298,7 +299,7 @@ export class ExprUtils {
         return isVariableValueExpr(expr) && isConstraintAssertion(exprContainer);
     }
 
-    public static getExprContainer(expr: Expression): Attribute | ConstraintAssertion | FunctionArgument | ImplicitlyTypedValue | MacroAttributeStatement | PatternAttributeConstraint | EnumEntry | FixSetStatement | CreateNodeAttributeAssignment | SetAttributeStatement | CreateNodeStatementAttrAssignment | ExportStatement {
+    public static getExprContainer(expr: Expression): Attribute | ConstraintAssertion | FunctionArgument | ImplicitlyTypedValue | MacroAttributeStatement | PatternAttributeConstraint | EnumEntry | FixSetStatement | CreateNodeAttributeAssignment | SetAttributeStatement | CreateNodeStatementAttrAssignment | ExportStatement | TemplateLiteral {
         if (isExpression(expr.$container)) {
             return this.getExprContainer(expr.$container);
         }

--- a/src/language/graph-constraint-language-module.ts
+++ b/src/language/graph-constraint-language-module.ts
@@ -4,6 +4,8 @@ import {GraphConstraintLanguageCompletionProvider} from "./graph-constraint-lang
 import {GraphConstraintLanguageFormatter} from "./graph-constraint-language-formatter.js";
 import {GraphConstraintLanguageSemanticTokenProvider} from "./graph-constraint-language-semantic-token-provider.js";
 import {GraphConstraintLanguageScopeProvider} from "./graph-constraint-language-scope-provider.js";
+import {GraphConstraintLanguageTokenBuilder} from "./graph-constraint-language-token-builder.js";
+import {GraphConstraintLanguageValueConverter} from "./graph-constraint-language-value-converter.js";
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -12,8 +14,8 @@ export type GraphConstraintLanguageAddedServices = {
     validation: {
         GraphConstraintLanguageValidator: GraphConstraintLanguageValidator
     },
-    references:{
-      ScopeProvider: GraphConstraintLanguageScopeProvider
+    references: {
+        ScopeProvider: GraphConstraintLanguageScopeProvider
     },
     lsp: {
         CompletionProvider: GraphConstraintLanguageCompletionProvider,
@@ -34,6 +36,10 @@ export type GraphConstraintLanguageServices = LangiumServices & GraphConstraintL
  * selected services, while the custom services must be fully specified.
  */
 export const GraphConstraintLanguageModule: Module<GraphConstraintLanguageServices, PartialLangiumServices & GraphConstraintLanguageAddedServices> = {
+    parser: {
+        TokenBuilder: () => new GraphConstraintLanguageTokenBuilder(),
+        ValueConverter: () => new GraphConstraintLanguageValueConverter()
+    },
     validation: {
         GraphConstraintLanguageValidator: (services) => new GraphConstraintLanguageValidator(services),
     },

--- a/src/language/graph-constraint-language-semantic-token-provider.ts
+++ b/src/language/graph-constraint-language-semantic-token-provider.ts
@@ -11,6 +11,7 @@ import {
     isDisableFixContainer,
     isEnableFixContainer,
     isEnforceAnnotation,
+    isExpression,
     isFixCreateEdgeStatement,
     isFixCreateNodeStatement,
     isFixDeleteEdgeStatement,
@@ -24,6 +25,7 @@ import {
     isPatternObject,
     isPatternObjectReference,
     isQualifiedValueExpr,
+    isTemplateLiteral,
     isTitleAnnotation,
     isTypedVariable,
     isUnaryExpression,
@@ -147,6 +149,14 @@ export class GraphConstraintLanguageSemanticTokenProvider extends AbstractSemant
         } else if (isCreateNodeAttributeAssignment(node)) {
             acceptor({node, property: "attr", type: SemanticTokenTypes.property});
             acceptor({node, keyword: "=", type: SemanticTokenTypes.operator});
+        } else if (isTemplateLiteral(node)) {
+            acceptor({node, keyword: "'", type: SemanticTokenTypes.string});
+
+            for (let i = 0; i < node.content.length; i++) {
+                if (!isExpression(node.content[i])) {
+                    acceptor({node, property: "content", index: i, type: SemanticTokenTypes.string});
+                }
+            }
         }
     }
 

--- a/src/language/graph-constraint-language-token-builder.ts
+++ b/src/language/graph-constraint-language-token-builder.ts
@@ -1,0 +1,59 @@
+import {DefaultTokenBuilder, GrammarAST, isTokenTypeArray} from "langium";
+import {IMultiModeLexerDefinition, TokenType, TokenVocabulary} from "chevrotain";
+
+const REGULAR_MODE = 'regular_mode';
+const TEMPLATE_MODE = 'template_mode';
+
+export class GraphConstraintLanguageTokenBuilder extends DefaultTokenBuilder {
+
+    override buildTokens(grammar: GrammarAST.Grammar, options?: { caseInsensitive?: boolean }): TokenVocabulary {
+        const tokenTypes = super.buildTokens(grammar, options);
+
+        if (isTokenTypeArray(tokenTypes)) {
+            // Regular mode just drops template literal middle & end
+            const regularModeTokens = tokenTypes
+                .filter(token => !['TEMPLATE_LITERAL_MIDDLE', 'TEMPLATE_LITERAL_END'].includes(token.name));
+            // Template mode needs to exclude the '}' keyword
+            const templateModeTokens = tokenTypes
+                .filter(token => !['}'].includes(token.name));
+
+            const multiModeLexerDef: IMultiModeLexerDefinition = {
+                modes: {
+                    [REGULAR_MODE]: regularModeTokens,
+                    [TEMPLATE_MODE]: templateModeTokens
+                },
+                defaultMode: REGULAR_MODE
+            };
+            return multiModeLexerDef;
+        } else {
+            throw new Error('Invalid token vocabulary received from DefaultTokenBuilder!');
+        }
+    }
+
+    protected override buildKeywordToken(
+        keyword: GrammarAST.Keyword,
+        terminalTokens: TokenType[],
+        caseInsensitive: boolean
+    ): TokenType {
+        let tokenType = super.buildKeywordToken(keyword, terminalTokens, caseInsensitive);
+
+        if (tokenType.name === '}') {
+            // The default } token will use [TEMPLATE_LITERAL_MIDDLE, TEMPLATE_LITERAL_END] as longer alts
+            // We need to delete the LONGER_ALT, they are not valid for the regular lexer mode
+            delete tokenType.LONGER_ALT;
+        }
+        return tokenType;
+    }
+
+    protected override buildTerminalToken(terminal: GrammarAST.TerminalRule): TokenType {
+        let tokenType = super.buildTerminalToken(terminal);
+
+        // Update token types to enter & exit template mode
+        if (tokenType.name === 'TEMPLATE_LITERAL_START') {
+            tokenType.PUSH_MODE = TEMPLATE_MODE;
+        } else if (tokenType.name === 'TEMPLATE_LITERAL_END') {
+            tokenType.POP_MODE = true;
+        }
+        return tokenType;
+    }
+}

--- a/src/language/graph-constraint-language-validator.ts
+++ b/src/language/graph-constraint-language-validator.ts
@@ -16,6 +16,7 @@ import {
     DisableDefaultNodeConstraintsAnnotation,
     DisableFixContainer,
     EnableFixContainer,
+    EnumValueExpr,
     FixCreateEdgeStatement,
     FixSetStatement,
     isClass,
@@ -87,7 +88,9 @@ export function registerValidationChecks(services: GraphConstraintLanguageServic
         ],
         BinaryExpression: [
             validator.checkBinaryExpressionValidity,
-            validator.checkBinaryExpressionOperatorPermitted
+        ],
+        EnumValueExpr: [
+            validator.checkEnumValueExpressionPermitted
         ],
         Annotation: [
             validator.checkAnnotationContextValidity
@@ -153,7 +156,7 @@ export namespace IssueCodes {
     export const DisableFixContainerHasEmptyModifier = "disable-fix-container-has-empty-modifier";
     export const EnableFixContainerIsUnboundAndNotEmpty = "enable-fix-container-is-unbound-and-not-empty";
     export const InvalidFixStatementInEmptyFixContainer = "invalid-fix-statement-in-empty-fix-container";
-    export const BinaryOperatorNotPermittedInContainer = "binary-operator-not-permitted-in-container";
+    export const EnumValueExprNotPermittedInContainer = "enum-value-expr-not-permitted-in-container";
 }
 
 /**
@@ -319,15 +322,13 @@ export class GraphConstraintLanguageValidator {
         }
     }*/
 
-    checkBinaryExpressionOperatorPermitted(bexpr: BinaryExpression, accept: ValidationAcceptor) {
-        const container = ExprUtils.getExprContainer(bexpr);
+    checkEnumValueExpressionPermitted(expr: EnumValueExpr, accept: ValidationAcceptor) {
+        const container = ExprUtils.getExprContainer(expr);
         if (isTemplateLiteral(container)) {
-            if (bexpr.operator == '&&' || bexpr.operator == '||') {
-                accept('error', `Boolean operator "${bexpr.operator}" cannot be used inside ${container.$type}`, {
-                    node: bexpr,
-                    code: IssueCodes.BinaryOperatorNotPermittedInContainer
-                })
-            }
+            accept('error', `EnumValues are not permitted inside ${container.$type}`, {
+                node: expr,
+                code: IssueCodes.EnumValueExprNotPermittedInContainer
+            })
         }
     }
 

--- a/src/language/graph-constraint-language-value-converter.ts
+++ b/src/language/graph-constraint-language-value-converter.ts
@@ -1,0 +1,13 @@
+import {convertString, CstNode, DefaultValueConverter, GrammarAST, ValueType} from 'langium';
+
+export class GraphConstraintLanguageValueConverter extends DefaultValueConverter {
+
+    protected override runConverter(rule: GrammarAST.AbstractRule, input: string, cstNode: CstNode): ValueType {
+        if (rule.name.startsWith('TEMPLATE_LITERAL')) {
+            // 'convertString' simply removes the first and last character of the input
+            return convertString(input);
+        } else {
+            return super.runConverter(rule, input, cstNode);
+        }
+    }
+}


### PR DESCRIPTION
In order to achieve explainable constraint evaluations, it is essential that we can formulate meaningful error messages. Template strings are often used to go beyond statically defined error messages. This allows us to use expressions within a string.

With this PullRequest, we introduce template strings for the first time in the Graph Constraint Language and use them in FixInfoStatements.