### PR TITLE
Feature/constraint language advanced fix set statement

### DIFF
--- a/src/language/constraints/gcl-entity-templates.ts
+++ b/src/language/constraints/gcl-entity-templates.ts
@@ -237,7 +237,7 @@ export class BinaryExpressionEntity {
         }
         if (isQualifiedValueExpr(expr) && expr.val.ref != undefined) {
             const qValueContainer = ExprUtils.getExprContainer(expr);
-            if (isTemplateLiteral(qValueContainer) && isFixInfoStatement(qValueContainer.$container)) {
+            if (isFixSetStatement(qValueContainer) || (isTemplateLiteral(qValueContainer) && isFixInfoStatement(qValueContainer.$container))) {
                 const attr: Attribute = expr.val.ref as Attribute;
                 const separatedAttributeAccess: string[] = expr.val.$refText.split(".");
                 if (separatedAttributeAccess.length != 2) {
@@ -414,7 +414,7 @@ export class FixSetStatementEntity implements FixStatementEntity {
     readonly patternNodeName: string;
     readonly attributeName: string;
     readonly customizationRequired: boolean;
-    readonly attributeValue: PrimaryExpressionEntity | undefined;
+    readonly attributeValue: ExpressionEntity | undefined;
 
     constructor(setStmt: FixSetStatement, resolver: GclReferenceStorage) {
         this.type = "SET";
@@ -428,13 +428,7 @@ export class FixSetStatementEntity implements FixStatementEntity {
         this.customizationRequired = setStmt.val == undefined;
 
         if (setStmt.val != undefined) {
-            if (ExprUtils.isEnumValueExpression(setStmt.val) && setStmt.val.val.ref != undefined) {
-                this.attributeValue = new PrimaryExpressionEntity(setStmt.val.val.ref.name, resolver, ModelModelingLanguageUtils.getQualifiedClassName(setStmt.val.val.ref.$container, setStmt.val.val.ref.$container.name), "", "", false, true);
-            } else if (isValueExpr(setStmt.val)) {
-                this.attributeValue = new PrimaryExpressionEntity(setStmt.val.value, resolver);
-            } else {
-                throw new Error(`Unable to assign attribute value: ${setStmt.attr.$refText}`);
-            }
+            this.attributeValue = new ExpressionEntity(BinaryExpressionEntity.generateChild(setStmt.val, resolver));
         }
     }
 }

--- a/src/language/definition/graph-constraint-language.langium
+++ b/src/language/definition/graph-constraint-language.langium
@@ -80,7 +80,7 @@ FixInfoStatement:
     'info' (msg=STRING | templateMsg=TemplateLiteral) ';';
 
 FixSetStatement:
-    'set' attr=[Attribute:QNAME] ('=' val=(ValueExpr | EnumValueExpr))? ';';
+    'set' attr=[Attribute:QNAME] ('=' val=Expression)? ';';
 
 FixDeleteNodeStatement:
     'delete' 'node' node=[TypedVariable:ID] ';';

--- a/src/language/expr-utils.ts
+++ b/src/language/expr-utils.ts
@@ -227,18 +227,7 @@ export class ExprUtils {
      * @param expr Expression to be checked
      */
     public static isIntExpression(expr: Expression): expr is NumberExpr {
-        if (expr.$type === "BinaryExpression") {
-            return this.isIntExpression(expr.left) && this.isIntExpression(expr.right);
-        } else if (isVariableValueExpr(expr)) {
-            if (expr.val.ref != undefined) {
-                const varTyping = this.getVariableTyping(expr.val.ref);
-                if (varTyping.isValidPrimitive && varTyping.type == ExprType.INTEGER) {
-                    return true;
-                }
-            }
-            return false;
-        }
-        return isNumberExpr(expr) && expr.value % 1 === 0;
+        return this.evaluateExpressionType(expr) == ExprType.INTEGER;
     }
 
     /**

--- a/src/language/graph-constraint-language-scope-provider.ts
+++ b/src/language/graph-constraint-language-scope-provider.ts
@@ -120,6 +120,18 @@ export class GraphConstraintLanguageScopeProvider extends DefaultScopeProvider {
                         }
                     })
                 }
+            } else if (isFixSetStatement(exprContainer)) {
+                const patternDeclaration: ConstraintPatternDeclaration = exprContainer.$container.$container;
+                const pattern = patternDeclaration.pattern.ref;
+                if (pattern != undefined) {
+                    pattern.objs.forEach(obj => {
+                        const refClass: AbstractElement | undefined = obj.var.typing.type?.ref;
+                        if (refClass != undefined && (isClass(refClass) || isInterface(refClass))) {
+                            const attrs: Attribute[] = refClass.body.filter(x => isAttribute(x)).map(x => x as Attribute);
+                            scopes.push(ScopingUtils.createScopeElementStream(attrs, this.descriptions, x => obj.var.name + "." + x.name, x => x));
+                        }
+                    })
+                }
             }
             return ScopingUtils.buildScopeFromAstNodeDesc(scopes, this.createScope);
         } else if (isEnumValueExpr(context.container)) {


### PR DESCRIPTION
As part of https://github.com/eMoflon/model-modeling-language/pull/8, MatchBasedStringInterpreter were introduced on the model server side, allowing expressions to be evaluated at runtime in the context of a match. This functionality should now also be provided for FixSetStatements, so that not only constant values, but also Boolean and arithmetic expressions can be used in combination with match node attributes.

This pull request contains the necessary grammar adjustment as well as the scoping for attributes within FixSetStatements.